### PR TITLE
New queries + fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 set -eu
 
-readonly JOERN_VERSION="v1.1.86"
+readonly JOERN_VERSION="v1.1.87"
 
 if [ "$(uname)" = 'Darwin' ]; then
   # get script location

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 set -eu
 
-readonly JOERN_VERSION="v1.1.83"
+readonly JOERN_VERSION="v1.1.86"
 
 if [ "$(uname)" = 'Darwin' ]; then
   # get script location

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,5 +1,5 @@
 /* Declare dependency versions in one place */
 object Versions {
-  val cpg = "1.3.33"
+  val cpg = "1.3.37"
   val overflowdb = "1.24"
 }

--- a/src/main/scala/io/joern/scanners/c/InsecureFunctions.scala
+++ b/src/main/scala/io/joern/scanners/c/InsecureFunctions.scala
@@ -16,7 +16,7 @@ object InsecureFunctions extends QueryBundle {
         | Avoid gets() function as it can lead to reads beyond buffer boundary and cause
         | buffer overflows. Some secure alternatives are fgets() and gets_s().
         |""".stripMargin,
-    score = 4, { cpg =>
+    score = 8, { cpg =>
       cpg.call("gets")
     }
   )
@@ -64,8 +64,8 @@ object InsecureFunctions extends QueryBundle {
     title = "Insecure functions strcat() or strncat() used",
     description =
       """
-        | Avoid strcat() or strncat() functions. The can be used insucurely causing non
-        | null-termianted strings leading to buffer overflows or memory corruption. 
+        | Avoid strcat() or strncat() functions. These can be used insecurely
+        | causing non null-termianted strings leading to memory corruption.
         | A secure alternative is strcat_s().
         |""".stripMargin,
     score = 4, { cpg =>

--- a/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
+++ b/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
@@ -15,8 +15,14 @@ object IntegerTruncations extends QueryBundle {
   def strlenAssignmentTruncations(): Query = Query(
     name = "strlen-truncation",
     author = Crew.fabs,
-    title = "Truncation in assigment involving strlen call",
-    description = "-",
+    title = "Truncation in assignment involving `strlen` call",
+    description =
+      """
+        |The return value of `strlen` is stored in a variable that is known
+        |to be of type `int` as opposed to `size_t`. `int` is only 32 bit
+        |wide on many 64 bit platforms, and thus, this may result in a
+        |truncation.
+        |""".stripMargin,
     score = 2, { cpg =>
       cpg
         .call("strlen")

--- a/src/main/scala/io/joern/scanners/c/NullTermination.scala
+++ b/src/main/scala/io/joern/scanners/c/NullTermination.scala
@@ -1,0 +1,46 @@
+package io.joern.scanners.c
+
+import io.joern.scanners.Crew
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.console.{Query, QueryBundle, q}
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+
+object NullTermination extends QueryBundle {
+
+  @q
+  def strncpyNoNullTerm()(implicit engineContext: EngineContext): Query =
+    Query(
+      name = "strncpy-no-null-term",
+      author = Crew.fabs,
+      title = "strncpy is used and no null termination is nearby",
+      description = """
+        | Upon calling `strncpy` with a source string that is larger
+        | than the destination buffer, the destination buffer is not
+        | null-terminated by `strncpy` and there is no explicit
+        | null termination nearby. This is unproblematic if the
+        | buffer size is at least 1 larger than the size passed
+        | to `strncpy`.
+        |""".stripMargin,
+      score = 4, { cpg =>
+        val allocations = cpg.call.name("malloc").argument(1).l
+        cpg
+          .call("strncpy")
+          .map { c =>
+            (c.method, c.argument(1), c.argument(3))
+          }
+          .filter {
+            case (method, dst, size) =>
+              dst.reachableBy(allocations).codeExact(size.code).nonEmpty &&
+                method.assignments
+                  .where(_.target.isArrayAccess.code(s"${dst.code}.*\\[.*"))
+                  .source
+                  .isLiteral
+                  .code(".*0.*")
+                  .isEmpty
+          }
+          .map(_._2)
+      }
+    )
+
+}

--- a/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
+++ b/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
@@ -23,7 +23,6 @@ object RetvalChecks extends QueryBundle {
         val targets = call.inAssignment.target.code.toSet
         (targets & identifiersInCheck).nonEmpty
       }
-
     }
   )
 

--- a/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
+++ b/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
@@ -6,11 +6,17 @@ import io.shiftleft.semanticcpg.language._
 
 object RetvalChecks extends QueryBundle {
 
+  @q
   def uncheckedRead(): Query = Query(
     name = "unchecked-read-recv",
     author = Crew.fabs,
     title = "Unchecked read/recv",
-    description = "<description>",
+    description =
+      """
+      |The return value of a read/recv call is not checked directly and the
+      |variable its return value has been assigned to (if any) does not
+      |occur in any check within the caller.
+      |""".stripMargin,
     score = 3.0, { cpg =>
       val callsNotDirectlyChecked = cpg
         .call("(read|recv)")

--- a/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -1,0 +1,43 @@
+package io.joern.scanners.c
+
+import io.joern.scanners.Crew
+import io.shiftleft.console._
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+
+object UseAfterFree extends QueryBundle {
+
+  @q
+  def freeFieldNoReassign()(implicit context: EngineContext): Query = Query(
+    name = "free-field-no-reassign",
+    author = Crew.fabs,
+    title = "A field of a parameter is free and not reassigned on all paths",
+    description =
+      """
+        | The function is able to modify a field of a structure passed in by
+        | the caller. It frees this field and does not guarantee that on
+        | all paths to the exit, the field is reassigned. If any
+        | caller now accesses the field, then it accesses memory that is no
+        | longer allocated.
+        |""".stripMargin,
+    score = 5.0, { cpg =>
+      val freeOfStructField = cpg
+        .call("free")
+        .where(
+          _.argument(1).ast
+            .isCallTo("<operator>.*[fF]ieldAccess.*")
+            .filter(x =>
+              x.method.parameter.name.toSet.contains(x.argument(1).code)))
+        .l
+
+      freeOfStructField.argument(1).filter { arg =>
+        arg.method.methodReturn.reachableByFlows(arg).foreach(println)
+        val exitNode = arg.method.methodReturn
+        exitNode.reachableBy(arg).nonEmpty
+      }
+
+    }
+  )
+
+}

--- a/src/test/resources/default.semantics
+++ b/src/test/resources/default.semantics
@@ -30,3 +30,4 @@
 "<operator>.addition" 1->-1 2->-1
 "<operator>.conditional" 2->-1 3->-1
 "woo" 1->-1
+"free" 1->1

--- a/src/test/scala/io/joern/scanners/c/NullTerminationTests.scala
+++ b/src/test/scala/io/joern/scanners/c/NullTerminationTests.scala
@@ -1,0 +1,47 @@
+package io.joern.scanners.c
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.console.scan._
+
+class NullTerminationTests extends Suite {
+
+  override val code =
+    """
+      |  // Null-termination is ensured if we can only copy
+      |  // less than `asize + 1` into the buffer
+      |int good() {
+      |  char *ptr = malloc(asize + 1);
+      |  strncpy(ptr, src, asize);
+      |}
+      |
+      |
+      | // Null-termination is also ensured if it is performed
+      | // explicitly
+      |int alsogood() {
+      |  char *ptr = malloc(asize);
+      |  strncpy(ptr, src, asize);
+      |  ptr[asize -1] = '\0';
+      |}
+      |
+      |// If src points to a string that is at least `asize` long,
+      |// then `ptr` will not be null-terminated after the `strncpy`
+      |// call.
+      |int bad() {
+      |  char *ptr = malloc(asize);
+      |  strncpy(ptr, src, asize);
+      |}
+      |
+      |""".stripMargin
+
+  "should find the bad code and not report the good" in {
+    val x = NullTermination.strncpyNoNullTerm()
+    x(cpg).flatMap(_.evidence) match {
+      case List(x: nodes.Expression) =>
+        x.method.name shouldBe "bad"
+      case _ =>
+        fail
+    }
+  }
+
+}

--- a/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
+++ b/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
@@ -14,7 +14,7 @@ class RetvalChecksTests extends Suite {
       |}
       |
       |void checked_after_assignment() {
-      | int nbytes = read(fd, buf, sizeof(buf));
+      | int nbytes = read(fd, buf, sizeof(buf))
       | if( nbytes != sizeof(buf)) {
       |
       | }
@@ -38,11 +38,12 @@ class RetvalChecksTests extends Suite {
       |""".stripMargin
 
   "should find unchecked read and not flag others" in {
-    val results =
-      RetvalChecks.uncheckedRead()(cpg).flatMap(_.evidence).collect {
-        case call: nodes.Call => call.method.name
-      }
-    results.toSet shouldBe Set("unchecked_read", "checks_something_else")
+    RetvalChecks.uncheckedRead()(cpg).flatMap(_.evidence) match {
+      case List(x: nodes.Call) =>
+        x.name shouldBe "read"
+        x.method.name shouldBe "unchecked_read"
+      case _ => fail
+    }
   }
 
 }

--- a/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
+++ b/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
@@ -14,7 +14,7 @@ class RetvalChecksTests extends Suite {
       |}
       |
       |void checked_after_assignment() {
-      | int nbytes = read(fd, buf, sizeof(buf))
+      | int nbytes = read(fd, buf, sizeof(buf));
       | if( nbytes != sizeof(buf)) {
       |
       | }
@@ -38,12 +38,11 @@ class RetvalChecksTests extends Suite {
       |""".stripMargin
 
   "should find unchecked read and not flag others" in {
-    RetvalChecks.uncheckedRead()(cpg).flatMap(_.evidence) match {
-      case List(x: nodes.Call) =>
-        x.name shouldBe "read"
-        x.method.name shouldBe "unchecked_read"
-      case _ => fail
-    }
+    val results =
+      RetvalChecks.uncheckedRead()(cpg).flatMap(_.evidence).collect {
+        case call: nodes.Call => call.method.name
+      }
+    results.toSet shouldBe Set("unchecked_read", "checks_something_else")
   }
 
 }

--- a/src/test/scala/io/joern/scanners/c/UseAfterFreeTests.scala
+++ b/src/test/scala/io/joern/scanners/c/UseAfterFreeTests.scala
@@ -1,0 +1,39 @@
+package io.joern.scanners.c
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.console.scan._
+import io.shiftleft.semanticcpg.language._
+
+class UseAfterFreeTests extends Suite {
+
+  override val code =
+    """
+      |void good(a_struct_type *a_struct) {
+      |
+      |  free(a_struct->ptr);
+      |  if (something) {
+      |    a_struct->ptr = NULL;
+      |    return;
+      |  }
+      |  a_struct->ptr = foo;
+      |}
+      |
+      |void bad(a_struct_type *a_struct) {
+      | free(a_struct->ptr);
+      | if (something) {
+      |   return;
+      | }
+      | a_struct->ptr = foo;
+      |}
+      |
+      |""".stripMargin
+
+  "should flag `bad` function only" in {
+    val x = UseAfterFree.freeFieldNoReassign()
+    x(cpg)
+      .flatMap(_.evidence)
+      .collect { case call: nodes.Call => call.method.name }
+      .toSet shouldBe Set("bad")
+  }
+
+}


### PR DESCRIPTION
* Upgraded score for use of `gets`
* Added query for a type of use-after-free
* Fixed a few descriptions
* Brought in a more evolved `strncpy` query