### PR TITLE
Increase query performance by taking methods first

### DIFF
--- a/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
+++ b/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
@@ -23,7 +23,8 @@ object CredentialDrop extends QueryBundle {
         |""".stripMargin,
     score = 2,
     traversal = { cpg =>
-      cpg.method("set(res|re|e|)uid")
+      cpg
+        .method("set(res|re|e|)uid")
         .callIn
         .whereNot(_.dominatedBy.isCall.name("set(res|re|e|)?gid"))
     }
@@ -42,7 +43,8 @@ object CredentialDrop extends QueryBundle {
         |""".stripMargin,
     score = 2,
     traversal = { cpg =>
-      cpg.method("set(res|re|e|)gid")
+      cpg
+        .method("set(res|re|e|)gid")
         .callIn
         .whereNot(_.dominatedBy.isCall.name("setgroups"))
     }

--- a/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
+++ b/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
@@ -6,6 +6,8 @@ import io.shiftleft.semanticcpg.language._
 
 object CredentialDrop extends QueryBundle {
 
+  implicit val resolver: ICallResolver = NoResolve
+
   @q
   def userCredDrop(): Query = Query(
     name = "setuid-without-setgid",
@@ -21,8 +23,8 @@ object CredentialDrop extends QueryBundle {
         |""".stripMargin,
     score = 2,
     traversal = { cpg =>
-      cpg.call
-        .name("set(res|re|e|)uid")
+      cpg.method("set(res|re|e|)uid")
+        .callIn
         .whereNot(_.dominatedBy.isCall.name("set(res|re|e|)?gid"))
     }
   )
@@ -40,8 +42,8 @@ object CredentialDrop extends QueryBundle {
         |""".stripMargin,
     score = 2,
     traversal = { cpg =>
-      cpg.call
-        .name("set(res|re|e|)gid")
+      cpg.method("set(res|re|e|)gid")
+        .callIn
         .whereNot(_.dominatedBy.isCall.name("setgroups"))
     }
   )

--- a/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
+++ b/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
@@ -6,6 +6,8 @@ import io.shiftleft.console._
 
 object DangerousFunctions extends QueryBundle {
 
+  implicit val resolver: ICallResolver = NoResolve
+
   @q
   def getsUsed(): Query = Query(
     name = "call-to-gets",
@@ -20,7 +22,7 @@ object DangerousFunctions extends QueryBundle {
     score = 8,
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
-      cpg.call("gets")
+      cpg.method("gets").callIn
     },
     docEndLine = sourcecode.Line(),
     docFileName = sourcecode.FileName()
@@ -41,10 +43,12 @@ object DangerousFunctions extends QueryBundle {
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
       cpg
-        .call("printf")
+        .method("printf")
+        .callIn
         .whereNot(_.argument.order(1).isLiteral) ++
         cpg
-          .call("(sprintf|vsprintf)")
+          .method("(sprintf|vsprintf)")
+          .callIn
           .whereNot(_.argument.order(2).isLiteral)
     },
     docEndLine = sourcecode.Line(),
@@ -64,7 +68,7 @@ object DangerousFunctions extends QueryBundle {
     score = 4,
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
-      cpg.call("scanf")
+      cpg.method("scanf").callIn
     },
     docEndLine = sourcecode.Line(),
     docFileName = sourcecode.FileName()
@@ -84,7 +88,7 @@ object DangerousFunctions extends QueryBundle {
     score = 4,
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
-      cpg.call("(strcat|strncat)")
+      cpg.method("(strcat|strncat)").callIn
     },
     docEndLine = sourcecode.Line(),
     docFileName = sourcecode.FileName()
@@ -106,7 +110,7 @@ object DangerousFunctions extends QueryBundle {
     score = 4,
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
-      cpg.call("(strcpy|strncpy)")
+      cpg.method("(strcpy|strncpy)").callIn
     },
     docEndLine = sourcecode.Line(),
     docFileName = sourcecode.FileName()
@@ -127,7 +131,7 @@ object DangerousFunctions extends QueryBundle {
     score = 4,
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
-      cpg.call("strtok")
+      cpg.method("strtok").callIn
     },
     docEndLine = sourcecode.Line(),
     docFileName = sourcecode.FileName()
@@ -146,7 +150,7 @@ object DangerousFunctions extends QueryBundle {
     score = 4,
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
-      cpg.call("getwd")
+      cpg.method("getwd").callIn
     },
     docEndLine = sourcecode.Line(),
     docFileName = sourcecode.FileName()

--- a/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
+++ b/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
@@ -8,6 +8,8 @@ import io.shiftleft.console._
 
 object HeapBasedOverflow extends QueryBundle {
 
+  implicit val resolver: ICallResolver = NoResolve
+
   /**
     * Find calls to malloc where the first argument contains an arithmetic expression,
     * the allocated buffer flows into memcpy as the first argument, and the third
@@ -25,12 +27,14 @@ object HeapBasedOverflow extends QueryBundle {
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
       val src = cpg
-        .call(".*malloc$")
+        .method(".*malloc$")
+        .callIn
         .where(_.argument(1).arithmetics)
         .l
 
       cpg
-        .call("memcpy")
+        .method("memcpy")
+        .callIn
         .l
         .filter { memcpyCall =>
           memcpyCall

--- a/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
+++ b/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
@@ -6,6 +6,8 @@ import io.shiftleft.console._
 
 object IntegerTruncations extends QueryBundle {
 
+  implicit val resolver: ICallResolver = NoResolve
+
   /**
     * Identify calls to `strlen` where return values are assigned
     * to variables of type `int`, potentially causing truncation
@@ -27,7 +29,8 @@ object IntegerTruncations extends QueryBundle {
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
       cpg
-        .call("strlen")
+        .method("strlen")
+        .callIn
         .inAssignment
         .target
         .evalType("(g?)int")

--- a/src/main/scala/io/joern/scanners/c/NullTermination.scala
+++ b/src/main/scala/io/joern/scanners/c/NullTermination.scala
@@ -8,6 +8,8 @@ import io.shiftleft.dataflowengineoss.queryengine.EngineContext
 
 object NullTermination extends QueryBundle {
 
+  implicit val resolver: ICallResolver = NoResolve
+
   @q
   def strncpyNoNullTerm()(implicit engineContext: EngineContext): Query =
     Query(
@@ -25,9 +27,10 @@ object NullTermination extends QueryBundle {
       score = 4,
       docStartLine = sourcecode.Line(),
       traversal = { cpg =>
-        val allocations = cpg.call.name(".*malloc$").argument(1).l
+        val allocations = cpg.method(".*malloc$").callIn.argument(1).l
         cpg
-          .call("strncpy")
+          .method("strncpy")
+          .callIn
           .map { c =>
             (c.method, c.argument(1), c.argument(3))
           }

--- a/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -8,6 +8,8 @@ import io.shiftleft.dataflowengineoss.queryengine.EngineContext
 
 object UseAfterFree extends QueryBundle {
 
+  implicit val resolver: ICallResolver = NoResolve
+
   @q
   def freeFieldNoReassign()(implicit context: EngineContext): Query = Query(
     name = "free-field-no-reassign",
@@ -27,7 +29,8 @@ object UseAfterFree extends QueryBundle {
     docStartLine = sourcecode.Line(),
     traversal = { cpg =>
       val freeOfStructField = cpg
-        .call("free")
+        .method("free")
+        .callIn
         .where(
           _.argument(1)
             .isCallTo("<operator>.*[fF]ieldAccess.*")


### PR DESCRIPTION
On average, the number of METHOD nodes in a CPG is a lot smaller than
the number of CALL nodes. Matching first on the METHOD name leads to
less expensive traversals.