### PR TITLE
Use macro for query initialization

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 set -eu
 
-readonly JOERN_VERSION="v1.1.98"
+readonly JOERN_VERSION="v1.1.99"
 
 if [ "$(uname)" = 'Darwin' ]; then
   # get script location

--- a/src/main/scala/io/joern/scanners/c/CopyLoops.scala
+++ b/src/main/scala/io/joern/scanners/c/CopyLoops.scala
@@ -2,43 +2,40 @@ package io.joern.scanners.c
 
 import io.joern.scanners._
 import io.shiftleft.console._
+import io.shiftleft.macros.QueryMacros._
 import io.shiftleft.semanticcpg.language._
 
 object CopyLoops extends QueryBundle {
 
   @q
-  def isCopyLoop(): Query = Query(
-    name = "copy-loop",
-    author = Crew.fabs,
-    title = "Copy loop detected",
-    description =
+  def isCopyLoop(): Query =
+    queryInit(
+      "copy-loop",
+      Crew.fabs,
+      "Copy loop detected",
       """
         |For (buf, indices) pairs, determine those inside control structures (for, while, if ...)
         |where any of the calls made outside of the body (block) are Inc operations. Determine
         |the first argument of that Inc operation and check if they are used as indices for
         |the write operation into the buffer.
         |""".stripMargin,
-    score = 2,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.assignment.target.isArrayAccess
-        .map { access =>
-          (access.array, access.subscripts.code.toSet)
-        }
-        .filter {
-          case (buf, subscripts) =>
-            val incIdentifiers = buf.inAst.isControlStructure.astChildren
-              .filterNot(_.isBlock)
-              .assignments
-              .target
-              .code
-              .toSet
-            (incIdentifiers & subscripts).nonEmpty
-        }
-        .map(_._1)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      2, { cpg =>
+        cpg.assignment.target.isArrayAccess
+          .map { access =>
+            (access.array, access.subscripts.code.toSet)
+          }
+          .filter {
+            case (buf, subscripts) =>
+              val incIdentifiers = buf.inAst.isControlStructure.astChildren
+                .filterNot(_.isBlock)
+                .assignments
+                .target
+                .code
+                .toSet
+              (incIdentifiers & subscripts).nonEmpty
+          }
+          .map(_._1)
+      },
+    ).asInstanceOf[Query]
 
 }

--- a/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
+++ b/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
@@ -3,17 +3,18 @@ package io.joern.scanners.c
 import io.joern.scanners._
 import io.shiftleft.console._
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.macros.QueryMacros._
 
 object CredentialDrop extends QueryBundle {
 
   implicit val resolver: ICallResolver = NoResolve
 
   @q
-  def userCredDrop(): Query = Query(
-    name = "setuid-without-setgid",
-    author = Crew.malte,
-    title = "Process user ID is changed without changing groups first",
-    description =
+  def userCredDrop(): Query =
+    queryInit(
+      "setuid-without-setgid",
+      Crew.malte,
+      "Process user ID is changed without changing groups first",
       """
         |The set*uid system calls do not affect the groups a process belongs to. However, often
         |there exists a group that is equivalent to a user (e.g. wheel or shadow groups are often
@@ -21,33 +22,31 @@ object CredentialDrop extends QueryBundle {
         |Group membership can only be changed by the root user.
         |Changes to the user should therefore always be preceded by calls to set*gid and setgroups,
         |""".stripMargin,
-    score = 2,
-    traversal = { cpg =>
-      cpg
-        .method("set(res|re|e|)uid")
-        .callIn
-        .whereNot(_.dominatedBy.isCall.name("set(res|re|e|)?gid"))
-    }
-  )
+      2, { cpg =>
+        cpg
+          .method("set(res|re|e|)uid")
+          .callIn
+          .whereNot(_.dominatedBy.isCall.name("set(res|re|e|)?gid"))
+      }
+    ).asInstanceOf[Query]
+
   @q
-  def groupCredDrop(): Query = Query(
-    name = "setgid-without-setgroups",
-    author = Crew.malte,
-    title =
+  def groupCredDrop(): Query =
+    queryInit(
+      "setgid-without-setgroups",
+      Crew.malte,
       "Process group membership is changed without setting ancillary groups first",
-    description =
       """
         |The set*gid system calls do not affect the ancillary groups a process belongs to.
         |Changes to the group membership should therefore always be preceded by a call to setgroups.
         |Otherwise the process may still be a secondary member of the group it tries to disavow.
         |""".stripMargin,
-    score = 2,
-    traversal = { cpg =>
-      cpg
-        .method("set(res|re|e|)gid")
-        .callIn
-        .whereNot(_.dominatedBy.isCall.name("setgroups"))
-    }
-  )
+      2, { cpg =>
+        cpg
+          .method("set(res|re|e|)gid")
+          .callIn
+          .whereNot(_.dominatedBy.isCall.name("setgroups"))
+      }
+    ).asInstanceOf[Query]
 
 }

--- a/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
+++ b/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
@@ -3,103 +3,88 @@ package io.joern.scanners.c
 import io.joern.scanners._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console._
+import io.shiftleft.macros.QueryMacros._
 
 object DangerousFunctions extends QueryBundle {
 
   implicit val resolver: ICallResolver = NoResolve
 
   @q
-  def getsUsed(): Query = Query(
-    name = "call-to-gets",
-    author = Crew.suchakra,
-    title = "Dangerous function gets() used",
-    description =
+  def getsUsed(): Query =
+    queryInit(
+      "call-to-gets",
+      Crew.suchakra,
+      "Dangerous function gets() used",
       """
         | Avoid `gets` function as it can lead to reads beyond buffer
         | boundary and cause
         | buffer overflows. Some secure alternatives are `fgets` and `gets_s`.
         |""".stripMargin,
-    score = 8,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method("gets").callIn
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      8, { cpg =>
+        cpg.method("gets").callIn
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def argvUsedInPrintf(): Query = Query(
-    name = "format-controlled-printf",
-    author = Crew.suchakra,
-    title = "Non-constant format string passed to printf/sprintf/vsprintf",
-    description =
+  def argvUsedInPrintf(): Query =
+    queryInit(
+      "format-controlled-printf",
+      Crew.suchakra,
+      "Non-constant format string passed to printf/sprintf/vsprintf",
       """
         | Avoid user controlled format strings like "argv" in printf, sprintf and vsprintf 
         | functions as they can cause memory corruption. Some secure
         | alternatives are `snprintf` and `vsnprintf`.
         |""".stripMargin,
-    score = 4,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg
-        .method("printf")
-        .callIn
-        .whereNot(_.argument.order(1).isLiteral) ++
+      4, { cpg =>
         cpg
-          .method("(sprintf|vsprintf)")
+          .method("printf")
           .callIn
-          .whereNot(_.argument.order(2).isLiteral)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+          .whereNot(_.argument.order(1).isLiteral) ++
+          cpg
+            .method("(sprintf|vsprintf)")
+            .callIn
+            .whereNot(_.argument.order(2).isLiteral)
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def scanfUsed(): Query = Query(
-    name = "call-to-scanf",
-    author = Crew.suchakra,
-    title = "Insecure function scanf() used",
-    description =
+  def scanfUsed(): Query =
+    queryInit(
+      "call-to-scanf",
+      Crew.suchakra,
+      "Insecure function scanf() used",
       """
         | Avoid `scanf` function as it can lead to reads beyond buffer
         | boundary and cause buffer overflows. A secure alternative is `fgets`.
         |""".stripMargin,
-    score = 4,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method("scanf").callIn
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      4, { cpg =>
+        cpg.method("scanf").callIn
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def strcatUsed(): Query = Query(
-    name = "call-to-strcat",
-    author = Crew.suchakra,
-    title = "Dangerous functions `strcat` or `strncat` used",
-    description =
+  def strcatUsed(): Query =
+    queryInit(
+      "call-to-strcat",
+      Crew.suchakra,
+      "Dangerous functions `strcat` or `strncat` used",
       """
         | Avoid `strcat` or `strncat` functions. These can be used insecurely
         | causing non null-termianted strings leading to memory corruption.
         | A secure alternative is `strcat_s`.
         |""".stripMargin,
-    score = 4,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method("(strcat|strncat)").callIn
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      4, { cpg =>
+        cpg.method("(strcat|strncat)").callIn
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def strcpyUsed(): Query = Query(
-    name = "call-to-strcpy",
-    author = Crew.suchakra,
-    title = "Dangerous functions `strcpy` or `strncpy` used",
-    description =
+  def strcpyUsed(): Query =
+    queryInit(
+      "call-to-strcpy",
+      Crew.suchakra,
+      "Dangerous functions `strcpy` or `strncpy` used",
       """
         | Avoid `strcpy` or `strncpy` function. `strcpy` does not check buffer
         | lengths.
@@ -107,53 +92,41 @@ object DangerousFunctions extends QueryBundle {
         | buffer overflows but does not null-terminate strings leading to
         | memory corruption. A secure alternative (on BSD) is `strlcpy`.
         |""".stripMargin,
-    score = 4,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method("(strcpy|strncpy)").callIn
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      4, { cpg =>
+        cpg.method("(strcpy|strncpy)").callIn
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def strtokUsed(): Query = Query(
-    name = "call-to-strtok",
-    author = Crew.suchakra,
-    title = "Dangerous function strtok() used",
-    description =
+  def strtokUsed(): Query =
+    queryInit(
+      "call-to-strtok",
+      Crew.suchakra,
+      "Dangerous function strtok() used",
       """
         | Avoid `strtok` function as it modifies the original string in place
         | and appends a null character after each token. This makes the
         | original string unsafe. Suggested alternative is `strtok_r` with
         | `saveptr`.
         |""".stripMargin,
-    score = 4,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method("strtok").callIn
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      4, { cpg =>
+        cpg.method("strtok").callIn
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def getwdUsed(): Query = Query(
-    name = "call-to-getwd",
-    author = Crew.claudiu,
-    title = "Dangerous function getwd() used",
-    description =
+  def getwdUsed(): Query =
+    queryInit(
+      "call-to-getwd",
+      Crew.claudiu,
+      "Dangerous function getwd() used",
       """
         | Avoid the `getwd` function, it does not check buffer lengths.
         | Use `getcwd` instead, as it checks the buffer size.
         |""".stripMargin,
-    score = 4,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method("getwd").callIn
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      4, { cpg =>
+        cpg.method("getwd").callIn
+      },
+    ).asInstanceOf[Query]
 
 }

--- a/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
+++ b/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
@@ -3,6 +3,7 @@ package io.joern.scanners.c
 import io.joern.scanners._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console._
+import io.shiftleft.macros.QueryMacros._
 
 object IntegerTruncations extends QueryBundle {
 
@@ -14,28 +15,24 @@ object IntegerTruncations extends QueryBundle {
     * on 64 bit platforms.
     * */
   @q
-  def strlenAssignmentTruncations(): Query = Query(
-    name = "strlen-truncation",
-    author = Crew.fabs,
-    title = "Truncation in assignment involving `strlen` call",
-    description =
+  def strlenAssignmentTruncations(): Query =
+    queryInit(
+      "strlen-truncation",
+      Crew.fabs,
+      "Truncation in assignment involving `strlen` call",
       """
         |The return value of `strlen` is stored in a variable that is known
         |to be of type `int` as opposed to `size_t`. `int` is only 32 bit
         |wide on many 64 bit platforms, and thus, this may result in a
         |truncation.
         |""".stripMargin,
-    score = 2,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg
-        .method("strlen")
-        .callIn
-        .inAssignment
-        .target
-        .evalType("(g?)int")
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      2, { cpg =>
+        cpg
+          .method("strlen")
+          .callIn
+          .inAssignment
+          .target
+          .evalType("(g?)int")
+      },
+    ).asInstanceOf[Query]
 }

--- a/src/main/scala/io/joern/scanners/c/Metrics.scala
+++ b/src/main/scala/io/joern/scanners/c/Metrics.scala
@@ -3,103 +3,84 @@ package io.joern.scanners.c
 import io.joern.scanners._
 import io.shiftleft.console._
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.macros.QueryMacros._
 
 object Metrics extends QueryBundle {
 
   @q
-  def tooManyParameters(n: Int = 4): Query = Query(
-    name = "too-many-params",
-    author = Crew.fabs,
-    title = s"Number of parameters larger than $n",
-    description =
+  def tooManyParameters(n: Int = 4): Query =
+    queryInit(
+      "too-many-params",
+      Crew.fabs,
+      s"Number of parameters larger than $n",
       s"This query identifies functions with more than $n formal parameters",
-    score = 1.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method.internal.filter(_.parameter.size > n)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      1.0, { cpg =>
+        cpg.method.internal.filter(_.parameter.size > n)
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def tooHighComplexity(n: Int = 4): Query = Query(
-    name = "too-high-complexity",
-    author = Crew.fabs,
-    title = s"Cyclomatic complexity higher than $n",
-    description =
+  def tooHighComplexity(n: Int = 4): Query =
+    queryInit(
+      "too-high-complexity",
+      Crew.fabs,
+      s"Cyclomatic complexity higher than $n",
       s"This query identifies functions with a cyclomatic complexity higher than $n",
-    score = 1.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method.internal.filter(_.controlStructure.size > n)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      1.0, { cpg =>
+        cpg.method.internal.filter(_.controlStructure.size > n)
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def tooLong(n: Int = 1000): Query = Query(
-    name = "too-long",
-    author = Crew.fabs,
-    title = s"More than $n lines",
-    description =
+  def tooLong(n: Int = 1000): Query =
+    queryInit(
+      "too-long",
+      Crew.fabs,
+      s"More than $n lines",
       s"This query identifies functions that are more than $n lines long",
-    score = 1.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method.internal.filter(_.numberOfLines > n)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      1.0, { cpg =>
+        cpg.method.internal.filter(_.numberOfLines > n)
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def multipleReturns(): Query = Query(
-    name = "multiple-returns",
-    author = Crew.fabs,
-    title = s"Multiple returns",
-    description = "This query identifies functions with more than one return",
-    score = 1.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method.internal.filter(_.ast.isReturn.l.size > 1)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+  def multipleReturns(): Query =
+    queryInit(
+      "multiple-returns",
+      Crew.fabs,
+      s"Multiple returns",
+      "This query identifies functions with more than one return",
+      1.0, { cpg =>
+        cpg.method.internal.filter(_.ast.isReturn.l.size > 1)
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def tooManyLoops(n: Int = 4): Query = Query(
-    name = "too-many-loops",
-    author = Crew.fabs,
-    title = s"More than $n loops",
-    description = s"This query identifies functions with more than $n loops",
-    score = 1.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method.internal
-        .filter(
-          _.ast.isControlStructure.parserTypeName("(For|Do|While).*").size > n)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+  def tooManyLoops(n: Int = 4): Query =
+    queryInit(
+      "too-many-loops",
+      Crew.fabs,
+      s"More than $n loops",
+      s"This query identifies functions with more than $n loops",
+      1.0, { cpg =>
+        cpg.method.internal
+          .filter(
+            _.ast.isControlStructure
+              .parserTypeName("(For|Do|While).*")
+              .size > n)
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def tooNested(n: Int = 3): Query = Query(
-    name = "too-nested",
-    author = Crew.fabs,
-    title = s"Nesting level higher than $n",
-    description =
+  def tooNested(n: Int = 3): Query =
+    queryInit(
+      "too-nested",
+      Crew.fabs,
+      s"Nesting level higher than $n",
       s"This query identifies functions with a nesting level higher than $n",
-    score = 1.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.method.internal.filter(_.depth(_.isControlStructure) > n)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      1.0, { cpg =>
+        cpg.method.internal.filter(_.depth(_.isControlStructure) > n)
+      },
+    ).asInstanceOf[Query]
 
 }

--- a/src/main/scala/io/joern/scanners/c/NullTermination.scala
+++ b/src/main/scala/io/joern/scanners/c/NullTermination.scala
@@ -5,6 +5,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.console.{Query, QueryBundle, q}
 import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+import io.shiftleft.macros.QueryMacros._
 
 object NullTermination extends QueryBundle {
 
@@ -12,11 +13,11 @@ object NullTermination extends QueryBundle {
 
   @q
   def strncpyNoNullTerm()(implicit engineContext: EngineContext): Query =
-    Query(
-      name = "strncpy-no-null-term",
-      author = Crew.fabs,
-      title = "strncpy is used and no null termination is nearby",
-      description = """
+    queryInit(
+      "strncpy-no-null-term",
+      Crew.fabs,
+      "strncpy is used and no null termination is nearby",
+      """
         | Upon calling `strncpy` with a source string that is larger
         | than the destination buffer, the destination buffer is not
         | null-terminated by `strncpy` and there is no explicit
@@ -24,9 +25,7 @@ object NullTermination extends QueryBundle {
         | buffer size is at least 1 larger than the size passed
         | to `strncpy`.
         |""".stripMargin,
-      score = 4,
-      docStartLine = sourcecode.Line(),
-      traversal = { cpg =>
+      4, { cpg =>
         val allocations = cpg.method(".*malloc$").callIn.argument(1).l
         cpg
           .method("strncpy")
@@ -46,8 +45,6 @@ object NullTermination extends QueryBundle {
           }
           .map(_._2)
       },
-      docEndLine = sourcecode.Line(),
-      docFileName = sourcecode.FileName()
-    )
+    ).asInstanceOf[Query]
 
 }

--- a/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
+++ b/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
@@ -2,45 +2,42 @@ package io.joern.scanners.c
 
 import io.joern.scanners.Crew
 import io.shiftleft.console._
+import io.shiftleft.macros.QueryMacros._
 import io.shiftleft.semanticcpg.language._
 
 object RetvalChecks extends QueryBundle {
 
   @q
-  def uncheckedReadRecvMalloc(): Query = Query(
-    name = "unchecked-read-recv-malloc",
-    author = Crew.fabs,
-    title = "Unchecked read/recv/malloc",
-    description =
+  def uncheckedReadRecvMalloc(): Query =
+    queryInit(
+      "unchecked-read-recv-malloc",
+      Crew.fabs,
+      "Unchecked read/recv/malloc",
       """
       |The return value of a read/recv/malloc call is not checked directly and
       |the variable it has been assigned to (if any) does not
       |occur in any check within the caller.
       |""".stripMargin,
-    score = 3.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      implicit val noResolve: NoResolve.type = NoResolve
-      val callsNotDirectlyChecked = cpg
-        .method("(read|recv|malloc)")
-        .callIn
-        .filterNot { y =>
-          val code = y.code
-          y.inAstMinusLeaf.isControlStructure.condition.code.exists { x =>
-            x.contains(code)
+      3.0, { cpg =>
+        implicit val noResolve: NoResolve.type = NoResolve
+        val callsNotDirectlyChecked = cpg
+          .method("(read|recv|malloc)")
+          .callIn
+          .filterNot { y =>
+            val code = y.code
+            y.inAstMinusLeaf.isControlStructure.condition.code.exists { x =>
+              x.contains(code)
+            }
           }
-        }
-        .l
+          .l
 
-      callsNotDirectlyChecked.filterNot { call =>
-        val inConditions = call.method.controlStructure.condition.ast.l;
-        val checkedVars = inConditions.isIdentifier.name.toSet ++ inConditions.isCall.code.toSet;
-        val targets = call.inAssignment.target.code.toSet
-        (targets & checkedVars).nonEmpty
-      }
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+        callsNotDirectlyChecked.filterNot { call =>
+          val inConditions = call.method.controlStructure.condition.ast.l;
+          val checkedVars = inConditions.isIdentifier.name.toSet ++ inConditions.isCall.code.toSet;
+          val targets = call.inAssignment.target.code.toSet
+          (targets & checkedVars).nonEmpty
+        }
+      },
+    ).asInstanceOf[Query]
 
 }

--- a/src/main/scala/io/joern/scanners/c/SignedLeftShift.scala
+++ b/src/main/scala/io/joern/scanners/c/SignedLeftShift.scala
@@ -3,30 +3,27 @@ package io.joern.scanners.c
 import io.joern.scanners._
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.console._
+import io.shiftleft.macros.QueryMacros._
 import io.shiftleft.semanticcpg.language._
 
 object SignedLeftShift extends QueryBundle {
 
   @q
-  def signedLeftShift(): Query = Query(
-    name = "signed-left-shift",
-    author = Crew.malte,
-    title = "Signed Shift May Cause Undefined Behavior",
-    description =
+  def signedLeftShift(): Query =
+    queryInit(
+      "signed-left-shift",
+      Crew.malte,
+      "Signed Shift May Cause Undefined Behavior",
       """
         |Signed integer overflow is undefined behavior. Shifts of signed values to the
         |left are very prone to overflow.
         |""".stripMargin,
-    score = 2,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      cpg.call
-        .nameExact(Operators.shiftLeft, Operators.assignmentShiftLeft)
-        .where(_.argument(1).typ.fullNameExact("int", "long"))
-        .filterNot(_.argument.isLiteral.size == 2) // assume such constant values produces a correct result
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+      2, { cpg =>
+        cpg.call
+          .nameExact(Operators.shiftLeft, Operators.assignmentShiftLeft)
+          .where(_.argument(1).typ.fullNameExact("int", "long"))
+          .filterNot(_.argument.isLiteral.size == 2) // assume such constant values produces a correct result
+      },
+    ).asInstanceOf[Query]
 
 }

--- a/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -7,6 +7,7 @@ import io.shiftleft.console._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+import io.shiftleft.macros.QueryMacros._
 import overflowdb.traversal.Traversal
 
 object UseAfterFree extends QueryBundle {
@@ -14,11 +15,11 @@ object UseAfterFree extends QueryBundle {
   implicit val resolver: ICallResolver = NoResolve
 
   @q
-  def freeFieldNoReassign()(implicit context: EngineContext): Query = Query(
-    name = "free-field-no-reassign",
-    author = Crew.fabs,
-    title = "A field of a parameter is free'd and not reassigned on all paths",
-    description =
+  def freeFieldNoReassign()(implicit context: EngineContext): Query =
+    queryInit(
+      "free-field-no-reassign",
+      Crew.fabs,
+      "A field of a parameter is free'd and not reassigned on all paths",
       """
         | The function is able to modify a field of a structure passed in by
         | the caller. It frees this field and does not guarantee that on
@@ -28,42 +29,37 @@ object UseAfterFree extends QueryBundle {
         | or clear the entire structure, as in that case, it is unlikely that the
         | passed in structure will be used again.
         |""".stripMargin,
-    score = 5.0,
-    docStartLine = sourcecode.Line(),
-    traversal = { cpg =>
-      val freeOfStructField = cpg
-        .method("free")
-        .callIn
-        .where(
-          _.argument(1)
-            .isCallTo("<operator>.*[fF]ieldAccess.*")
-            .filter(x =>
-              x.method.parameter.name.toSet.contains(x.argument(1).code))
-        )
-        .whereNot(_.argument(1).isCall.argument(1).filter { struct =>
-          struct.method.ast.isCall
-            .name(".*free$", "memset", "bzero")
-            .argument(1)
-            .codeExact(struct.code)
-            .nonEmpty
-        })
-        .l
+      5.0, { cpg =>
+        val freeOfStructField = cpg
+          .method("free")
+          .callIn
+          .where(
+            _.argument(1)
+              .isCallTo("<operator>.*[fF]ieldAccess.*")
+              .filter(x =>
+                x.method.parameter.name.toSet.contains(x.argument(1).code))
+          )
+          .whereNot(_.argument(1).isCall.argument(1).filter { struct =>
+            struct.method.ast.isCall
+              .name(".*free$", "memset", "bzero")
+              .argument(1)
+              .codeExact(struct.code)
+              .nonEmpty
+          })
+          .l
 
-      freeOfStructField.argument(1).filter { arg =>
-        arg.method.methodReturn.reachableBy(arg).nonEmpty
-      }
-
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+        freeOfStructField.argument(1).filter { arg =>
+          arg.method.methodReturn.reachableBy(arg).nonEmpty
+        }
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def freeReturnedValue()(implicit context: EngineContext): Query = Query(
-    name = "free-returned-value",
-    author = Crew.malte,
-    title = "A value that is returned through a parameter is free'd in a path",
-    description =
+  def freeReturnedValue()(implicit context: EngineContext): Query =
+    queryInit(
+      "free-returned-value",
+      Crew.malte,
+      "A value that is returned through a parameter is free'd in a path",
       """
         |The function sets a field of a function parameter to a value of a local
         |variable.
@@ -73,86 +69,83 @@ object UseAfterFree extends QueryBundle {
         |
         |Finds bugs like CVE-2019-18902.
         |""".stripMargin,
-    score = 5.0,
-    traversal = { cpg =>
-      def outParams =
-        cpg.parameter
-          .typeFullName(".+\\*")
-          .whereNot(
-            _.referencingIdentifiers
-              .argumentIndex(1)
-              .inCall
-              .nameExact(Operators.assignment, Operators.addressOf))
+      5.0, { cpg =>
+        def outParams =
+          cpg.parameter
+            .typeFullName(".+\\*")
+            .whereNot(
+              _.referencingIdentifiers
+                .argumentIndex(1)
+                .inCall
+                .nameExact(Operators.assignment, Operators.addressOf))
 
-      def assignedValues =
-        outParams.referencingIdentifiers
-          .argumentIndex(1)
-          .inCall
-          .nameExact(Operators.indirectFieldAccess,
-                     Operators.indirection,
-                     Operators.indirectIndexAccess)
-          .argumentIndex(1)
-          .inCall
-          .nameExact(Operators.assignment)
-          .argument(2)
-          .isIdentifier
+        def assignedValues =
+          outParams.referencingIdentifiers
+            .argumentIndex(1)
+            .inCall
+            .nameExact(Operators.indirectFieldAccess,
+                       Operators.indirection,
+                       Operators.indirectIndexAccess)
+            .argumentIndex(1)
+            .inCall
+            .nameExact(Operators.assignment)
+            .argument(2)
+            .isIdentifier
 
-      def freeAssigned =
-        assignedValues
-          .map(
-            id =>
-              (id,
-               id.refsTo
-                 .flatMap {
-                   case p: MethodParameterIn => p.referencingIdentifiers
-                   case v: Local             => v.referencingIdentifiers
-                 }
-                 .inCall
-                 .name("(.*_)?free")))
+        def freeAssigned =
+          assignedValues
+            .map(
+              id =>
+                (id,
+                 id.refsTo
+                   .flatMap {
+                     case p: MethodParameterIn => p.referencingIdentifiers
+                     case v: Local             => v.referencingIdentifiers
+                   }
+                   .inCall
+                   .name("(.*_)?free")))
 
-      freeAssigned
-        .filter { case (id, freeCall) => freeCall.dominatedBy.exists(_ == id) }
-        .flatMap(_._1)
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+        freeAssigned
+          .filter {
+            case (id, freeCall) => freeCall.dominatedBy.exists(_ == id)
+          }
+          .flatMap(_._1)
+      },
+    ).asInstanceOf[Query]
 
   @q
-  def freePostDominatesUsage()(implicit context: EngineContext): Query = Query(
-    name = "free-follows-value-reuse",
-    author = Crew.malte,
-    title = "A value that is free'd is reused without reassignment.",
-    description = """
+  def freePostDominatesUsage()(implicit context: EngineContext): Query =
+    queryInit(
+      "free-follows-value-reuse",
+      Crew.malte,
+      "A value that is free'd is reused without reassignment.",
+      """
         |A value is used after being free'd in a path that leads to it
         |without reassignment.
         |
         |Modeled after CVE-2019-18903.
         |""".stripMargin,
-    score = 5.0,
-    traversal = { cpg =>
-      cpg.method
-        .name("(.*_)?free")
-        .filter(_.parameter.size == 1)
-        .callIn
-        .where(_.argument(1).isIdentifier)
-        .flatMap(f => {
-          val freedIdentifierCode = f.argument(1).code
-          val postDom = f.postDominatedBy.toSet
+      5.0, { cpg =>
+        cpg.method
+          .name("(.*_)?free")
+          .filter(_.parameter.size == 1)
+          .callIn
+          .where(_.argument(1).isIdentifier)
+          .flatMap(f => {
+            val freedIdentifierCode = f.argument(1).code
+            val postDom = f.postDominatedBy.toSet
 
-          val assignedPostDom = postDom.isIdentifier
-            .where(_.inAssignment)
-            .codeExact(freedIdentifierCode)
-            .flatMap(id => id ++ id.postDominatedBy)
+            val assignedPostDom = postDom.isIdentifier
+              .where(_.inAssignment)
+              .codeExact(freedIdentifierCode)
+              .flatMap(id => id ++ id.postDominatedBy)
 
-          postDom
-            .removedAll(assignedPostDom)
-            .isIdentifier
-            .codeExact(freedIdentifierCode)
-        })
-    },
-    docEndLine = sourcecode.Line(),
-    docFileName = sourcecode.FileName()
-  )
+            postDom
+              .removedAll(assignedPostDom)
+              .isIdentifier
+              .codeExact(freedIdentifierCode)
+          })
+      },
+    ).asInstanceOf[Query]
 
 }


### PR DESCRIPTION
Required for the traversalAsString value to be set automatically.

I've tried moving the queryInit().asInstanceOf[Query] to the method of a
separate object so that named parameters can be used and the casting at
the end is not needed, unfortunately the current macro takes the
argument's name as string instead of its expanded form. It might be
possible to create a new macro which doesn't do that and create a
prettier instantiation method, in the meantime this will have to do.