### PR TITLE
Allow dumping queries without requiring `joern-scan --dump`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,4 +11,5 @@ jobs:
         java-version: 1.8
     - name: Run tests
       run: |
-        sbt test scalafmtCheck
+        sbt test scalafmtCheck stage
+        ./target/universal/stage/bin/batteries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,7 @@ jobs:
       - run: sbt scalafmtCheck test stage
       - run: sbt ciReleaseTagNextVersion createDistribution
       - run: sha512sum ./querydb.zip > ./querydb.zip.sha512
-      - run: ./install.sh
-      - run: ./joern-scan --dump || echo "{}" > /tmp/querydb.json
+      - run: ./target/universal/stage/bin/batteries
       - run: cp /tmp/querydb.json .
       - name: Export ENV vars
         run:

--- a/build.sbt
+++ b/build.sbt
@@ -21,24 +21,24 @@ libraryDependencies ++= Seq(
 )
 
 // We exclude a few jars that the main joern distribution already includes
-Universal / mappings := (Universal / mappings).value.filterNot {
-   case (_, path) => path.contains("org.scala") ||
-    path.contains("net.sf.trove4") ||
-    path.contains("com.google.guava") ||
-    path.contains("org.apache.logging") ||
-    path.contains("com.google.protobuf") ||
-    path.contains("com.lihaoyi.u") ||
-    path.contains("io.shiftleft") ||
-    path.contains("org.typelevel") ||
-    path.contains("io.undertow") ||
-    path.contains("com.chuusai") ||
-    path.contains("io.get-coursier") ||
-    path.contains("io.circe") ||
-    path.contains("net.java.dev") ||
-    path.contains("com.github.javaparser") ||
-    path.contains("org.javassist") ||
-    path.contains("com.lihaoyi.ammonite")
-}
+// Universal / mappings := (Universal / mappings).value.filterNot {
+//    case (_, path) => path.contains("org.scala") ||
+//     path.contains("net.sf.trove4") ||
+//     path.contains("com.google.guava") ||
+//     path.contains("org.apache.logging") ||
+//     path.contains("com.google.protobuf") ||
+//     path.contains("com.lihaoyi.u") ||
+//     path.contains("io.shiftleft") ||
+//     path.contains("org.typelevel") ||
+//     path.contains("io.undertow") ||
+//     path.contains("com.chuusai") ||
+//     path.contains("io.get-coursier") ||
+//     path.contains("io.circe") ||
+//     path.contains("net.java.dev") ||
+//     path.contains("com.github.javaparser") ||
+//     path.contains("org.javassist") ||
+//     path.contains("com.lihaoyi.ammonite")
+// }
 
 sources in (Compile,doc) := Seq.empty
 publishArtifact in (Compile, packageDoc) := false

--- a/build.sbt
+++ b/build.sbt
@@ -20,26 +20,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.1" % Test
 )
 
-// We exclude a few jars that the main joern distribution already includes
-// Universal / mappings := (Universal / mappings).value.filterNot {
-//    case (_, path) => path.contains("org.scala") ||
-//     path.contains("net.sf.trove4") ||
-//     path.contains("com.google.guava") ||
-//     path.contains("org.apache.logging") ||
-//     path.contains("com.google.protobuf") ||
-//     path.contains("com.lihaoyi.u") ||
-//     path.contains("io.shiftleft") ||
-//     path.contains("org.typelevel") ||
-//     path.contains("io.undertow") ||
-//     path.contains("com.chuusai") ||
-//     path.contains("io.get-coursier") ||
-//     path.contains("io.circe") ||
-//     path.contains("net.java.dev") ||
-//     path.contains("com.github.javaparser") ||
-//     path.contains("org.javassist") ||
-//     path.contains("com.lihaoyi.ammonite")
-// }
-
 sources in (Compile,doc) := Seq.empty
 publishArtifact in (Compile, packageDoc) := false
 
@@ -49,7 +29,27 @@ createDistribution := {
   val pkgBin = (Universal/packageBin).value
   val dstArchive = "./querydb.zip"
   IO.copy(
-    List((pkgBin, file(dstArchive))),
+    List((pkgBin, file(dstArchive))).filter {
+      case (_,x) =>
+        val path = x.getPath
+          path.contains("org.scala") ||
+          path.contains("net.sf.trove4") ||
+          path.contains("com.google.guava") ||
+          path.contains("org.apache.logging") ||
+          path.contains("com.google.protobuf") ||
+          path.contains("com.lihaoyi.u") ||
+          path.contains("io.shiftleft") ||
+          path.contains("org.typelevel") ||
+          path.contains("io.undertow") ||
+          path.contains("com.chuusai") ||
+          path.contains("io.get-coursier") ||
+          path.contains("io.circe") ||
+          path.contains("net.java.dev") ||
+          path.contains("com.github.javaparser") ||
+          path.contains("org.javassist") ||
+          path.contains("com.lihaoyi.ammonite")
+    }
+    ,
     CopyOptions(overwrite = true, preserveLastModified = true, preserveExecutable = true)
   )
   println(s"created distribution - resulting files: $dstArchive")

--- a/src/main/scala/io/joern/dumpq/Main.scala
+++ b/src/main/scala/io/joern/dumpq/Main.scala
@@ -1,0 +1,40 @@
+package io.joern.dumpq
+
+import io.shiftleft.console.{DefaultArgumentProvider, QueryDatabase}
+import io.shiftleft.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.native.Serialization
+
+import scala.reflect.runtime.universe._
+
+object Main extends App {
+
+  dumpQueries()
+
+  def dumpQueries(): Unit = {
+    implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
+    implicit val formats: AnyRef with Formats = Serialization.formats(NoTypeHints)
+    val queryDb = new QueryDatabase(new JoernDefaultArgumentProvider(0))
+    // TODO allow specifying file from the outside and make this portable
+    val outFileName = "/tmp/querydb.json"
+    better.files
+      .File(outFileName)
+      .write(
+        Serialization.write(queryDb.allQueries)
+      )
+    println(s"Queries written to: $outFileName")
+  }
+
+  class JoernDefaultArgumentProvider(maxCallDepth: Int)(implicit context: EngineContext) extends DefaultArgumentProvider {
+
+    override def defaultArgument(method: MethodSymbol, im: InstanceMirror, x: Symbol, i: Int): Option[Any] = {
+      if (x.typeSignature.toString.endsWith("EngineContext")) {
+        Some(context.copy(config = EngineConfig(maxCallDepth = maxCallDepth)))
+      } else {
+        super.defaultArgument(method, im, x, i)
+      }
+    }
+  }
+
+}

--- a/src/main/scala/io/joern/dumpq/Main.scala
+++ b/src/main/scala/io/joern/dumpq/Main.scala
@@ -14,7 +14,8 @@ object Main extends App {
 
   def dumpQueries(): Unit = {
     implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
-    implicit val formats: AnyRef with Formats = Serialization.formats(NoTypeHints)
+    implicit val formats: AnyRef with Formats =
+      Serialization.formats(NoTypeHints)
     val queryDb = new QueryDatabase(new JoernDefaultArgumentProvider(0))
     // TODO allow specifying file from the outside and make this portable
     val outFileName = "/tmp/querydb.json"
@@ -26,9 +27,14 @@ object Main extends App {
     println(s"Queries written to: $outFileName")
   }
 
-  class JoernDefaultArgumentProvider(maxCallDepth: Int)(implicit context: EngineContext) extends DefaultArgumentProvider {
+  class JoernDefaultArgumentProvider(maxCallDepth: Int)(
+      implicit context: EngineContext)
+      extends DefaultArgumentProvider {
 
-    override def defaultArgument(method: MethodSymbol, im: InstanceMirror, x: Symbol, i: Int): Option[Any] = {
+    override def defaultArgument(method: MethodSymbol,
+                                 im: InstanceMirror,
+                                 x: Symbol,
+                                 i: Int): Option[Any] = {
       if (x.typeSignature.toString.endsWith("EngineContext")) {
         Some(context.copy(config = EngineConfig(maxCallDepth = maxCallDepth)))
       } else {


### PR DESCRIPTION
Make coupling between query-database and joern a little less crazy by not relying on `joern-scan --dump` in release builds of query-database.