### PR TITLE
Remove now unnecessary casts to `Query`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 set -eu
 
-readonly JOERN_VERSION="v1.1.99"
+readonly JOERN_VERSION="v1.1.100"
 
 if [ "$(uname)" = 'Darwin' ]; then
   # get script location

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,4 +1,4 @@
 /* Declare dependency versions in one place */
 object Versions {
-  val cpg = "1.3.49"
+  val cpg = "1.3.50"
 }

--- a/src/main/scala/io/joern/scanners/c/CopyLoops.scala
+++ b/src/main/scala/io/joern/scanners/c/CopyLoops.scala
@@ -36,6 +36,6 @@ object CopyLoops extends QueryBundle {
           }
           .map(_._1)
       },
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
+++ b/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
@@ -28,7 +28,7 @@ object CredentialDrop extends QueryBundle {
           .callIn
           .whereNot(_.dominatedBy.isCall.name("set(res|re|e|)?gid"))
       }
-    ).asInstanceOf[Query]
+    )
 
   @q
   def groupCredDrop(): Query =
@@ -47,6 +47,6 @@ object CredentialDrop extends QueryBundle {
           .callIn
           .whereNot(_.dominatedBy.isCall.name("setgroups"))
       }
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
+++ b/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
@@ -23,7 +23,7 @@ object DangerousFunctions extends QueryBundle {
       8, { cpg =>
         cpg.method("gets").callIn
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def argvUsedInPrintf(): Query =
@@ -46,7 +46,7 @@ object DangerousFunctions extends QueryBundle {
             .callIn
             .whereNot(_.argument.order(2).isLiteral)
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def scanfUsed(): Query =
@@ -61,7 +61,7 @@ object DangerousFunctions extends QueryBundle {
       4, { cpg =>
         cpg.method("scanf").callIn
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def strcatUsed(): Query =
@@ -77,7 +77,7 @@ object DangerousFunctions extends QueryBundle {
       4, { cpg =>
         cpg.method("(strcat|strncat)").callIn
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def strcpyUsed(): Query =
@@ -95,7 +95,7 @@ object DangerousFunctions extends QueryBundle {
       4, { cpg =>
         cpg.method("(strcpy|strncpy)").callIn
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def strtokUsed(): Query =
@@ -112,7 +112,7 @@ object DangerousFunctions extends QueryBundle {
       4, { cpg =>
         cpg.method("strtok").callIn
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def getwdUsed(): Query =
@@ -127,6 +127,6 @@ object DangerousFunctions extends QueryBundle {
       4, { cpg =>
         cpg.method("getwd").callIn
       },
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
+++ b/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
@@ -46,6 +46,6 @@ object HeapBasedOverflow extends QueryBundle {
               .hasNext
           }
       },
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
+++ b/src/main/scala/io/joern/scanners/c/IntegerTruncations.scala
@@ -34,5 +34,5 @@ object IntegerTruncations extends QueryBundle {
           .target
           .evalType("(g?)int")
       },
-    ).asInstanceOf[Query]
+    )
 }

--- a/src/main/scala/io/joern/scanners/c/Metrics.scala
+++ b/src/main/scala/io/joern/scanners/c/Metrics.scala
@@ -17,7 +17,7 @@ object Metrics extends QueryBundle {
       1.0, { cpg =>
         cpg.method.internal.filter(_.parameter.size > n)
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def tooHighComplexity(n: Int = 4): Query =
@@ -29,7 +29,7 @@ object Metrics extends QueryBundle {
       1.0, { cpg =>
         cpg.method.internal.filter(_.controlStructure.size > n)
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def tooLong(n: Int = 1000): Query =
@@ -41,7 +41,7 @@ object Metrics extends QueryBundle {
       1.0, { cpg =>
         cpg.method.internal.filter(_.numberOfLines > n)
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def multipleReturns(): Query =
@@ -53,7 +53,7 @@ object Metrics extends QueryBundle {
       1.0, { cpg =>
         cpg.method.internal.filter(_.ast.isReturn.l.size > 1)
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def tooManyLoops(n: Int = 4): Query =
@@ -69,7 +69,7 @@ object Metrics extends QueryBundle {
               .parserTypeName("(For|Do|While).*")
               .size > n)
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def tooNested(n: Int = 3): Query =
@@ -81,6 +81,6 @@ object Metrics extends QueryBundle {
       1.0, { cpg =>
         cpg.method.internal.filter(_.depth(_.isControlStructure) > n)
       },
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/NullTermination.scala
+++ b/src/main/scala/io/joern/scanners/c/NullTermination.scala
@@ -45,6 +45,6 @@ object NullTermination extends QueryBundle {
           }
           .map(_._2)
       },
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
+++ b/src/main/scala/io/joern/scanners/c/RetvalChecks.scala
@@ -38,6 +38,6 @@ object RetvalChecks extends QueryBundle {
           (targets & checkedVars).nonEmpty
         }
       },
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/SignedLeftShift.scala
+++ b/src/main/scala/io/joern/scanners/c/SignedLeftShift.scala
@@ -24,6 +24,6 @@ object SignedLeftShift extends QueryBundle {
           .where(_.argument(1).typ.fullNameExact("int", "long"))
           .filterNot(_.argument.isLiteral.size == 2) // assume such constant values produces a correct result
       },
-    ).asInstanceOf[Query]
+    )
 
 }

--- a/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -52,7 +52,7 @@ object UseAfterFree extends QueryBundle {
           arg.method.methodReturn.reachableBy(arg).nonEmpty
         }
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def freeReturnedValue()(implicit context: EngineContext): Query =
@@ -111,7 +111,7 @@ object UseAfterFree extends QueryBundle {
           }
           .flatMap(_._1)
       },
-    ).asInstanceOf[Query]
+    )
 
   @q
   def freePostDominatesUsage()(implicit context: EngineContext): Query =
@@ -146,6 +146,6 @@ object UseAfterFree extends QueryBundle {
               .codeExact(freedIdentifierCode)
           })
       },
-    ).asInstanceOf[Query]
+    )
 
 }


### PR DESCRIPTION
With CPG 1.3.50, we no longer need to cast the result of `queryInit` to `Query`.