### PR TITLE
Compiler Optimization: Simple Constant Detection

### DIFF
--- a/src/main/scala/io/joern/scanners/Crew.scala
+++ b/src/main/scala/io/joern/scanners/Crew.scala
@@ -7,5 +7,6 @@ object Crew {
   val fabs = "@fabsx00"
   val claudiu = "@ursachec"
   val malte = "@maltek"
+  val dave = "@DavidBakerEffendi"
 
 }

--- a/src/main/scala/io/joern/scanners/QueryTags.scala
+++ b/src/main/scala/io/joern/scanners/QueryTags.scala
@@ -18,4 +18,5 @@ object QueryTags {
   val integers = "integers"
   val strings = "strings"
   val sqlInjection = "sql-injection"
+  val compilerOptimization = "compiler-optimization"
 }

--- a/src/main/scala/io/joern/scanners/QueryTags.scala
+++ b/src/main/scala/io/joern/scanners/QueryTags.scala
@@ -19,4 +19,5 @@ object QueryTags {
   val strings = "strings"
   val sqlInjection = "sql-injection"
   val compilerOptimization = "compiler-optimization"
+
 }

--- a/src/main/scala/io/joern/scanners/java/CompilerOptimizations.scala
+++ b/src/main/scala/io/joern/scanners/java/CompilerOptimizations.scala
@@ -55,7 +55,7 @@ object CompilerOptimizations extends QueryBundle {
             case _                              => Option.empty
           }
       }),
-      tags = List(QueryTags.compilerOptimization, QueryTags.default)
+      tags = List(QueryTags.compilerOptimization)
     )
 
 }

--- a/src/main/scala/io/joern/scanners/java/CompilerOptimizations.scala
+++ b/src/main/scala/io/joern/scanners/java/CompilerOptimizations.scala
@@ -30,19 +30,23 @@ object CompilerOptimizations extends QueryBundle {
       score = 1,
       withStrRep({ cpg =>
         cpg.assignment
-          // Determine which identifiers are assigned to exactly once
+        // Determine which identifiers are assigned to exactly once
           .groupBy(_.argument.order(1).code.l)
           .map { case (_, as: Traversal[Assignment]) => as.l }
           .filter(_.size == 1)
           .flatMap {
-            case as: List[Assignment] => Option(as.head.argument.head, as.head.argument.l.head.typ.l)
+            case as: List[Assignment] =>
+              Option(as.head.argument.head, as.head.argument.l.head.typ.l)
             case _ => Option.empty
           }
           // Filter only primitives
-          .filter { case (_: Identifier, ts: List[Type]) =>
-            ts.nonEmpty &&
-              ts.head.namespace.l.exists { x => x.name.contains("<global>") } &&
-              !ts.head.fullName.contains("[]")
+          .filter {
+            case (_: Identifier, ts: List[Type]) =>
+              ts.nonEmpty &&
+                ts.head.namespace.l.exists { x =>
+                  x.name.contains("<global>")
+                } &&
+                !ts.head.fullName.contains("[]")
           }
           .map { case (i: Identifier, _: List[Type]) => i }
       }),

--- a/src/main/scala/io/joern/scanners/java/CompilerOptimizations.scala
+++ b/src/main/scala/io/joern/scanners/java/CompilerOptimizations.scala
@@ -1,0 +1,52 @@
+package io.joern.scanners.java
+
+import io.joern.scanners._
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Type}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.console._
+import io.shiftleft.macros.QueryMacros._
+import io.shiftleft.semanticcpg.language.operatorextension.opnodes.Assignment
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+import overflowdb.traversal.Traversal
+
+object CompilerOptimizations extends QueryBundle {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  @q
+  def simpleConstant()(implicit context: EngineContext): Query =
+    Query.make(
+      name = "simple-constant-detection",
+      author = Crew.dave,
+      title =
+        "Simple Constant Detection: Finds identifiers with primitives only assigned once",
+      description =
+        """
+          |Detect variables holding simple constants. A term is a simple constant
+          |if it assigns a primitive constant, or if all its operands are simple constants.
+          |
+          |This should be optimized by the compiler during compile time.
+          |""".stripMargin,
+      score = 1,
+      withStrRep({ cpg =>
+        cpg.assignment
+          // Determine which identifiers are assigned to exactly once
+          .groupBy(_.argument.order(1).code.l)
+          .map { case (_, as: Traversal[Assignment]) => as.l }
+          .filter(_.size == 1)
+          .flatMap {
+            case as: List[Assignment] => Option(as.head.argument.head, as.head.argument.l.head.typ.l)
+            case _ => Option.empty
+          }
+          // Filter only primitives
+          .filter { case (_: Identifier, ts: List[Type]) =>
+            ts.nonEmpty &&
+              ts.head.namespace.l.exists { x => x.name.contains("<global>") } &&
+              !ts.head.fullName.contains("[]")
+          }
+          .map { case (i: Identifier, _: List[Type]) => i }
+      }),
+      tags = List(QueryTags.compilerOptimization, QueryTags.default)
+    )
+
+}


### PR DESCRIPTION
This is a simple query that I found is fun to show the capabilities of Joern. Essentially this will check for identifiers not assigned to more than once. I made this with Java in mind but I suppose this is a fairly language agnostic application.

In terms of testing - I note that Java queries don't have tests but if we so wish I could just put his under C queries or make a "general" package that uses C code as an example that I can test with. Example code to use for verification:

```scala
importCode.c.fromString("""
       void main()
       {
         int a = 1;
         int b = 1 + 3;
         int c = 3;
         a = 2;
       }""") 
```
Should return something like:
```scala
res10: List[Identifier] = List(
  Identifier(
    id -> 1000114L,
    argumentIndex -> 1,
    code -> "c",
    columnNumber -> Some(value = 13),
    lineNumber -> Some(value = 6),
    name -> "c",
    order -> 1,
    typeFullName -> "int"
  ),
  Identifier(
    id -> 1000108L,
    argumentIndex -> 1,
    code -> "b",
    columnNumber -> Some(value = 13),
    lineNumber -> Some(value = 5),
    name -> "b",
    order -> 1,
    typeFullName -> "int"
  )
)
```