### PR TITLE
Add negative code examples along with FileOpRace and SocketApi tests

### DIFF
--- a/src/main/scala/io/joern/scanners/c/CopyLoops.scala
+++ b/src/main/scala/io/joern/scanners/c/CopyLoops.scala
@@ -38,6 +38,7 @@ object CopyLoops extends QueryBundle {
           }
           .map(_._1)
       }),
+      tags = List(QueryTags.default),
       codeExamples = CodeExamples(
         List("""
           |

--- a/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
+++ b/src/main/scala/io/joern/scanners/c/CredentialDrop.scala
@@ -34,21 +34,21 @@ object CredentialDrop extends QueryBundle {
       codeExamples = CodeExamples(
         List("""
           |
-          |void good() {
-          |  setgroups();
-          |  setresgid();
-          |  setresuid();
-          |}
-          |
-          |""".stripMargin),
-        List("""
-          |
           |void bad1() {
           |  setresuid();
           |}
           |
           |void bad3() {
           |  setgroups();
+          |  setresuid();
+          |}
+          |
+          |""".stripMargin),
+        List("""
+          |
+          |void good() {
+          |  setgroups();
+          |  setresgid();
           |  setresuid();
           |}
           |
@@ -80,8 +80,7 @@ object CredentialDrop extends QueryBundle {
       codeExamples = CodeExamples(
         List("""
           |
-          |void good() {
-          |  setgroups();
+          |void bad2() {
           |  setresgid();
           |  setresuid();
           |}
@@ -89,7 +88,8 @@ object CredentialDrop extends QueryBundle {
           |""".stripMargin),
         List("""
           |
-          |void bad2() {
+          |void good() {
+          |  setgroups();
           |  setresgid();
           |  setresuid();
           |}

--- a/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
+++ b/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
@@ -27,28 +27,30 @@ object DangerousFunctions extends QueryBundle {
       }),
       tags = List(QueryTags.badfn, QueryTags.default),
       codeExamples = CodeExamples(
-        List("""
-            |
-            |int insecure_gets() {
-            |  char str[DST_BUFFER_SIZE];
-            |  gets(str);
-            |  printf("%s", str);
-            |  return 0;
-            |}
-            |
-            |""".stripMargin),
-        List("""
-            |
-            |int secure_gets() {
-            |  FILE *fp;
-            |  fp = fopen("file.txt" , "r");
-            |  char str[DST_BUFFER_SIZE];
-            |  fgets(str, DST_BUFFER_SIZE, fp);
-            |  printf("%s", str);
-            |  return 0;
-            |}
-            |
-            |""".stripMargin)
+        List(
+          """
+          |
+          |int insecure_gets() {
+          |  char str[DST_BUFFER_SIZE];
+          |  gets(str);
+          |  printf("%s", str);
+          |  return 0;
+          |}
+          |
+          |""".stripMargin),
+        List(
+          """
+          |
+          |int secure_gets() {
+          |  FILE *fp;
+          |  fp = fopen("file.txt" , "r");
+          |  char str[DST_BUFFER_SIZE];
+          |  fgets(str, DST_BUFFER_SIZE, fp);
+          |  printf("%s", str);
+          |  return 0;
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -131,7 +133,8 @@ object DangerousFunctions extends QueryBundle {
       }),
       tags = List(QueryTags.badfn),
       codeExamples = CodeExamples(
-        List("""
+        List(
+          """
           |
           |int insecure_scanf() {
           |  char name[12];
@@ -141,7 +144,14 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List(
+          """
+          |
+          |void secure_fgets(char *buf, int size, FILE *stream) {
+          |    fgets(buf, size, stream);
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -166,6 +176,13 @@ object DangerousFunctions extends QueryBundle {
         List(
           """
           |
+          |void insecure_strcat(char *dest, char *src) {
+          |    strcat(dest, src);
+          |}
+          |
+          |""".stripMargin,
+          """
+          |
           |int insecure_strncat() {
           |  char buf[BUF_SIZE];
           |  strncat(buf, another_buffer, BUF_SIZE - strlen(buf)); // remediation is (BUFF_SIZE - strlen(buf) - 1)
@@ -173,7 +190,14 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List(
+          """
+          |
+          |void secure_strcat_s(char *dest, rsize_t destsz, char *src) {
+          |    strcat_s(dest, destsz, src);
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -200,6 +224,13 @@ object DangerousFunctions extends QueryBundle {
         List(
           """
           |
+          |void insecure_strcpy(char *dest, char *src) {
+          |    strcpy(dest, src);
+          |}
+          |
+          |""".stripMargin,
+          """
+          |
           |int insecure_strncpy() {
           |  char buf[BUF_SIZE];
           |  strncpy(buf, default_value, BUF_SIZE); // remediation is (BUFF_SIZE - 1)
@@ -207,7 +238,14 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List(
+          """
+          |
+          |void secure_strlcpy(char *dest, char *src, size_t size) {
+          |    strlcpy(dest, src, size);
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -243,7 +281,14 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List(
+          """
+          |
+          |void secure_strtok_r(char *src, char *delim, char **saveptr) {
+          |    strtok_r(src, delim, saveptr);
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -274,7 +319,11 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List("""
+          |void secure_getcwd(char *buf, size_t len) {
+          |    getcwd(buf, len);
+          |}
+          |""")
       )
     )
 }

--- a/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
+++ b/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
@@ -27,8 +27,7 @@ object DangerousFunctions extends QueryBundle {
       }),
       tags = List(QueryTags.badfn, QueryTags.default),
       codeExamples = CodeExamples(
-        List(
-          """
+        List("""
           |
           |int insecure_gets() {
           |  char str[DST_BUFFER_SIZE];
@@ -38,8 +37,7 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List(
-          """
+        List("""
           |
           |int secure_gets() {
           |  FILE *fp;
@@ -133,8 +131,7 @@ object DangerousFunctions extends QueryBundle {
       }),
       tags = List(QueryTags.badfn),
       codeExamples = CodeExamples(
-        List(
-          """
+        List("""
           |
           |int insecure_scanf() {
           |  char name[12];
@@ -144,8 +141,7 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List(
-          """
+        List("""
           |
           |void secure_fgets(char *buf, int size, FILE *stream) {
           |    fgets(buf, size, stream);
@@ -189,9 +185,9 @@ object DangerousFunctions extends QueryBundle {
           |  return 0
           |}
           |
-          |""".stripMargin),
-        List(
-          """
+          |""".stripMargin
+        ),
+        List("""
           |
           |void secure_strcat_s(char *dest, rsize_t destsz, char *src) {
           |    strcat_s(dest, destsz, src);
@@ -237,9 +233,9 @@ object DangerousFunctions extends QueryBundle {
           |  return 0
           |}
           |
-          |""".stripMargin),
-        List(
-          """
+          |""".stripMargin
+        ),
+        List("""
           |
           |void secure_strlcpy(char *dest, char *src, size_t size) {
           |    strlcpy(dest, src, size);
@@ -281,8 +277,7 @@ object DangerousFunctions extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List(
-          """
+        List("""
           |
           |void secure_strtok_r(char *src, char *delim, char **saveptr) {
           |    strtok_r(src, delim, saveptr);

--- a/src/main/scala/io/joern/scanners/c/FileOpRace.scala
+++ b/src/main/scala/io/joern/scanners/c/FileOpRace.scala
@@ -77,8 +77,7 @@ object FileOpRace extends QueryBundle {
       }),
       tags = List(QueryTags.raceCondition, QueryTags.default),
       codeExamples = CodeExamples(
-        List(
-          """
+        List("""
           |
           |void insecure_race(char *path) {
           |    chmod(path, 0);
@@ -86,8 +85,7 @@ object FileOpRace extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List(
-          """
+        List("""
           |
           |void secure_handle(char *path) {
           |    FILE *file = fopen(path, "r");

--- a/src/main/scala/io/joern/scanners/c/FileOpRace.scala
+++ b/src/main/scala/io/joern/scanners/c/FileOpRace.scala
@@ -11,10 +11,9 @@ import overflowdb.traversal.Traversal
 
 object FileOpRace extends QueryBundle {
 
-  implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
-
   @q
-  def fileOperationRace(): Query =
+  def fileOperationRace()(implicit context: EngineContext): Query = {
+
     Query.make(
       name = "file-operation-race",
       author = Crew.malte,
@@ -95,4 +94,5 @@ object FileOpRace extends QueryBundle {
           |""".stripMargin)
       )
     )
+  }
 }

--- a/src/main/scala/io/joern/scanners/c/Metrics.scala
+++ b/src/main/scala/io/joern/scanners/c/Metrics.scala
@@ -28,7 +28,13 @@ object Metrics extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List("""
+          |
+          |void good(int a, int b, int c, int d) {
+          |
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -62,7 +68,14 @@ object Metrics extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List("""
+          |
+          |void good(int x, int y) {
+          |    if (x > 0) {/* Stuff */ } else { /* Stuff */ }
+          |    if (y > 0) {/* Stuff */ } else { /* Stuff */ }
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -98,7 +111,13 @@ object Metrics extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List("""
+          |
+          |int func_with_few_lines(int x) {
+          |  x++;
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -126,7 +145,13 @@ object Metrics extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List("""
+          |
+          |int func_without_multiple_returns() {
+          |  return 0;
+          |}
+          |
+          |""".stripMargin)
       )
     )
 
@@ -160,7 +185,13 @@ object Metrics extends QueryBundle {
           |  while(bar()){}
           |}
           |""".stripMargin),
-        List()
+        List("""
+          |int not_many_loops() {
+          |  while (true) {
+          |    // Do something
+          |  }
+          |}
+          |""".stripMargin)
       )
     )
 
@@ -191,7 +222,15 @@ object Metrics extends QueryBundle {
           |}
           |
           |""".stripMargin),
-        List()
+        List("""
+          |
+          |int func_with_nesting_level_of_1(int foo) {
+          |  if (foo > 10) {
+          |    // Do something
+          |  }
+          |}
+          |
+          |""")
       )
     )
 }

--- a/src/main/scala/io/joern/scanners/c/SocketApi.scala
+++ b/src/main/scala/io/joern/scanners/c/SocketApi.scala
@@ -3,6 +3,7 @@ package io.joern.scanners.c
 import io.joern.scanners.{Crew, QueryTags}
 import io.shiftleft.console.{Query, QueryBundle, q}
 import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.macros.QueryMacros._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console._
@@ -10,8 +11,10 @@ import QueryLangExtensions._
 
 object SocketApi extends QueryBundle {
 
+  implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
+
   @q
-  def uncheckedSend()(implicit context: EngineContext): Query =
+  def uncheckedSend(): Query =
     Query.make(
       name = "socket-send",
       author = Crew.fabs,
@@ -31,6 +34,38 @@ object SocketApi extends QueryBundle {
           .callIn
           .returnValueNotChecked
       }),
-      tags = List(QueryTags.default, QueryTags.posix)
+      tags = List(QueryTags.default, QueryTags.posix),
+      codeExamples = CodeExamples(
+        List(
+          """
+          |
+          |void return_not_checked(int sockfd, void *buf, size_t len, int flags) {
+          |    send(sockfd, buf, len, flags);
+          |}
+          |
+          |""".stripMargin),
+        List(
+          """
+          |
+          |void return_checked(int sockfd, void *buf, size_t len, int flags) {
+          |    if (send(sockfd, buf, len, flags) <= 0) {
+          |        // Do something
+          |    }
+          |}
+          |
+          |""".stripMargin,
+          """
+          |
+          |void return_var_checked(int sockfd, void *buf, size_t len, int flags) {
+          |    ssize_t ret = send(sockfd, buf, len, flags);
+          |
+          |    if (ret <= 0) {
+          |        // Do something
+          |    }
+          |}
+          |
+          |""".stripMargin)
+      )
+
     )
 }

--- a/src/main/scala/io/joern/scanners/c/SocketApi.scala
+++ b/src/main/scala/io/joern/scanners/c/SocketApi.scala
@@ -11,10 +11,8 @@ import QueryLangExtensions._
 
 object SocketApi extends QueryBundle {
 
-  implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
-
   @q
-  def uncheckedSend(): Query =
+  def uncheckedSend()(implicit context: EngineContext): Query =
     Query.make(
       name = "socket-send",
       author = Crew.fabs,

--- a/src/main/scala/io/joern/scanners/c/SocketApi.scala
+++ b/src/main/scala/io/joern/scanners/c/SocketApi.scala
@@ -64,8 +64,8 @@ object SocketApi extends QueryBundle {
           |    }
           |}
           |
-          |""".stripMargin)
+          |""".stripMargin
+        )
       )
-
     )
 }

--- a/src/test/resources/default.semantics
+++ b/src/test/resources/default.semantics
@@ -1,33 +1,39 @@
-"<operator>.assignment" 2->1
-"<operators>.assignmentAnd" 2->1 1->1
-"<operators>.assignmentArithmeticShiftRight" 2->1 1->1
-"<operator>.assignmentDivision" 2->1 1->1
-"<operators>.assignmentExponentiation" 2->1 1->1
-"<operators>.assignmentLogicalShiftRight" 2->1 1->1
-"<operator>.assignmentMinus" 2->1 1->1
-"<operators>.assignmentModulo" 2->1 1->1
-"<operator>.assignmentMultiplication" 2->1 1->1
-"<operators>.assignmentOr" 2->1 1->1
-"<operator>.assignmentPlus" 2->1 1->1
-"<operators>.assignmentShiftLeft" 2->1 1->1
-"<operators>.assignmentXor" 2->1 1->1
-"<operator>.postDecrement" 1->1
-"<operator>.preDecrement" 1->1
-"<operator>.postIncrement" 1->1
-"<operator>.preIncrement" 1->1
-"<operator>.memberAccess" 1->-1
-"<operator>.indirectComputedMemberAccess" 1->-1
-"<operator>.indirectMemberAccess" 1->-1
-"<operator>.computedMemberAccess" 1->-1
-"<operator>.indirection" 1->-1
-"<operator>.addressOf" 1->-1
-"<operator>.fieldAccess" 1->-1
-"<operator>.indirectFieldAccess" 1->-1
-"<operator>.indexAccess" 1->-1
-"<operator>.indirectIndexAccess" 1->-1
-"<operator>.pointerShift" 1->-1
-"<operator>.getElementPtr" 1->-1
+# "<operator>.sizeOf" reduces the FPs
+# 1->-1 first parameter mapped to return value (-1)
 "<operator>.addition" 1->-1 2->-1
+"<operator>.addressOf" 1->-1
+"<operator>.assignment" 2->1
+"<operator>.assignmentAnd" 2->1 1->1
+"<operator>.assignmentArithmeticShiftRight" 2->1 1->1
+"<operator>.assignmentDivision" 2->1 1->1
+"<operator>.assignmentExponentiation" 2->1 1->1
+"<operator>.assignmentLogicalShiftRight" 2->1 1->1
+"<operator>.assignmentMinus" 2->1 1->1
+"<operator>.assignmentModulo" 2->1 1->1
+"<operator>.assignmentMultiplication" 2->1 1->1
+"<operator>.assignmentOr" 2->1 1->1
+"<operator>.assignmentPlus" 2->1 1->1
+"<operator>.assignmentShiftLeft" 2->1 1->1
+"<operator>.assignmentXor" 2->1 1->1
+"<operator>.computedMemberAccess" 1->-1
 "<operator>.conditional" 2->-1 3->-1
-"woo" 1->-1
+"<operator>.fieldAccess" 1->-1
+"<operator>.getElementPtr" 1->-1
+"<operator>.incBy 2->1 3->1 4->1"
+"<operator>.indexAccess" 1->-1
+"<operator>.indirectComputedMemberAccess" 1->-1
+"<operator>.indirectFieldAccess" 1->-1
+"<operator>.indirectIndexAccess" 1->-1
+"<operator>.indirectMemberAccess" 1->-1
+"<operator>.indirection" 1->-1
+"<operator>.memberAccess" 1->-1
+"<operator>.pointerShift" 1->-1
+"<operator>.postDecrement" 1->1
+"<operator>.postIncrement" 1->1
+"<operator>.preDecrement" 1->1
+"<operator>.preIncrement" 1->1
+"<operator>.sizeOf"
 "free" 1->1
+"scanf" 2->2
+"strcmp" 1->-1 2->-1
+"woo" 1->-1

--- a/src/test/scala/io/joern/scanners/c/DangerousFunctionsTests.scala
+++ b/src/test/scala/io/joern/scanners/c/DangerousFunctionsTests.scala
@@ -37,19 +37,27 @@ class DangerousFunctionsTests extends QueryTestSuite {
   }
 
   "find insecure strncat() function usage" in {
-    queryBundle.strcatUsed()(cpg).map(_.evidence) match {
-      case List(List(expr: nodes.Expression)) =>
-        expr.method.name shouldBe "insecure_strncat"
-      case _ => fail()
-    }
+    val results =
+      queryBundle.strcatUsed()(cpg)
+      .flatMap(_.evidence)
+      .collect { case x: nodes.Call => x }
+      .method
+      .name
+      .toSet
+
+    results shouldBe Set("insecure_strcat", "insecure_strncat")
   }
 
   "find insecure strncpy() function usage" in {
-    queryBundle.strcpyUsed()(cpg).map(_.evidence) match {
-      case List(List(expr: nodes.Expression)) =>
-        expr.method.name shouldBe "insecure_strncpy"
-      case _ => fail()
-    }
+    val results =
+      queryBundle.strcpyUsed()(cpg)
+      .flatMap(_.evidence)
+      .collect { case x: nodes.Call => x }
+      .method
+      .name
+      .toSet
+
+    results shouldBe Set("insecure_strcpy", "insecure_strncpy")
   }
 
   "find insecure strtok() function usage" in {

--- a/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
+++ b/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
@@ -1,0 +1,22 @@
+package io.joern.scanners.c
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.console.scan._
+import io.shiftleft.semanticcpg.language._
+
+class FileOpRaceTests extends QueryTestSuite {
+
+  override def queryBundle = FileOpRace
+
+  "should flag function `insecure_race` only" in {
+    val results =
+      queryBundle.fileOperationRace()(cpg)
+      .flatMap(_.evidence)
+      .collect { case x: nodes.Call => x }
+      .method
+      .name
+      .toSet
+    results shouldBe Set("insecure_race")
+  }
+
+}

--- a/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
+++ b/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
@@ -2,15 +2,29 @@ package io.joern.scanners.c
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.console.scan._
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Parser, Semantics}
 import io.shiftleft.semanticcpg.language._
 
 class FileOpRaceTests extends QueryTestSuite {
 
   override def queryBundle = FileOpRace
 
+  override val code: String =
+     """
+      |void insecure_race(char *path) {
+      |    chmod(path, 0);
+      |    rename(path, "/some/new/path");
+      |}
+      |void secure_handle(char *path) {
+      |    FILE *file = fopen(path, "r");
+      |    fchown(fileno(file), 0, 0);
+      |}
+      |""".stripMargin
+
   "should flag function `insecure_race` only" in {
-    val results =
-      queryBundle.fileOperationRace()(cpg)
+    val queries = queryBundle.fileOperationRace()
+    val results = queries(cpg)
       .flatMap(_.evidence)
       .collect { case x: nodes.Call => x }
       .method

--- a/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
+++ b/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
@@ -9,9 +9,30 @@ class SocketApiTests extends QueryTestSuite {
 
   override def queryBundle = SocketApi
 
+  override val code: String =
+    """
+      |void return_not_checked(int sockfd, void *buf, size_t len, int flags) {
+      |    send(sockfd, buf, len, flags);
+      |}
+      |
+      |void return_checked(int sockfd, void *buf, size_t len, int flags) {
+      |    if (send(sockfd, buf, len, flags) <= 0) {
+      |        // Do something
+      |    }
+      |}
+      |
+      |void return_var_checked(int sockfd, void *buf, size_t len, int flags) {
+      |    ssize_t ret = send(sockfd, buf, len, flags);
+      |
+      |    if (ret <= 0) {
+      |        // Do something
+      |    }
+      |}
+      |""".stripMargin
+
   "should flag function `return_not_checked` only" in {
-    val results =
-      queryBundle.uncheckedSend()(cpg)
+    val queries = queryBundle.uncheckedSend()
+    val results = queries(cpg)
       .flatMap(_.evidence)
       .collect { case x: nodes.Call => x }
       .method

--- a/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
+++ b/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
@@ -1,0 +1,23 @@
+package io.joern.scanners.c
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.console.scan._
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.iterableToTraversal
+
+class SocketApiTests extends QueryTestSuite {
+
+  override def queryBundle = SocketApi
+
+  "should flag function `return_not_checked` only" in {
+    val results =
+      queryBundle.uncheckedSend()(cpg)
+      .flatMap(_.evidence)
+      .collect { case x: nodes.Call => x }
+      .method
+      .name
+      .toSet
+    results shouldBe Set("return_not_checked")
+  }
+
+}


### PR DESCRIPTION
# Notes
* Added negative code examples to all queries that were missing them.
* Switched code examples for `setgid-without-setgroups` and `setuid-without-setgid` as the good and bad were swapped.
* Added tests for `FileOpRace` and `SocketApi` queries.

**NOTE:** The `constant-array-access-no-check` query is broken. This PR neither fixes it, no adds tests for it. Both of those will follow in a future PR.

# Testing
```
> sbt test
> sbt createDistribution
```

## Implicits change testing
```
❯ ./joern-scan --overwrite ../examples-joern/file_operation_race.c
Result: 3.0 : Two file operations on the same path can act on different files: /home/johannes/code/examples-joern/file_operation_race.c:2:insecure_race
Result: 3.0 : Two file operations on the same path can act on different files: /home/johannes/code/examples-joern/file_operation_race.c:3:insecure_race
```
```
❯ ./joern-scan --overwrite ../examples-joern/socket_send.c
Result: 2.0 : Unchecked call to send: /home/johannes/code/examples-joern/socket_send.c:2:return_not_checked
```