### PR TITLE
Set default argument provider in test QueryBundles

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild/organization := "io.joern"
 ThisBuild/scalaVersion := "2.13.5" 
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 
-val cpgVersion = "1.3.239"
+val cpgVersion = "1.3.264"
 
 enablePlugins(JavaAppPackaging)
 enablePlugins(GitVersioning)

--- a/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
+++ b/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
@@ -2,25 +2,11 @@ package io.joern.scanners.c
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.console.scan._
-import io.shiftleft.dataflowengineoss.queryengine.EngineContext
-import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Parser, Semantics}
 import io.shiftleft.semanticcpg.language._
 
 class FileOpRaceTests extends QueryTestSuite {
 
   override def queryBundle = FileOpRace
-
-  override val code: String =
-     """
-      |void insecure_race(char *path) {
-      |    chmod(path, 0);
-      |    rename(path, "/some/new/path");
-      |}
-      |void secure_handle(char *path) {
-      |    FILE *file = fopen(path, "r");
-      |    fchown(fileno(file), 0, 0);
-      |}
-      |""".stripMargin
 
   "should flag function `insecure_race` only" in {
     val queries = queryBundle.fileOperationRace()


### PR DESCRIPTION
Without the provider, the `@q` annotation does not return the queries
which have a `context` implicit specified in their function definition.
This leads to test suites returning empty strings for the `code`
property queries match on in the test suites.
