### PR TITLE
Refactor tests that find matching functions based on calls

### DIFF
--- a/src/test/scala/io/joern/scanners/c/CredentialDropTests.scala
+++ b/src/test/scala/io/joern/scanners/c/CredentialDropTests.scala
@@ -9,22 +9,17 @@ class CredentialDropTests extends QueryTestSuite {
 
   override def queryBundle = CredentialDrop
 
-  "strict order of credential dropping function calls should be observed" in {
-    queryBundle
-      .userCredDrop()(cpg)
-      .flatMap(_.evidence)
-      .cast[nodes.Call]
-      .method
-      .name
-      .toSet shouldBe Set("bad1", "bad3")
+  "find cases where user changes are not preceded by calls to set*gid and setgroups" in {
+    val query = queryBundle.userCredDrop()
+    val results = findMatchingCalls(query)
 
-    queryBundle
-      .groupCredDrop()(cpg)
-      .flatMap(_.evidence)
-      .cast[nodes.Call]
-      .method
-      .name
-      .toSet shouldBe Set("bad2")
+    results shouldBe Set("bad1", "bad3")
   }
 
+  "find cases where group membership changes are not preceded by a call to setgroups" in {
+    val query = queryBundle.groupCredDrop()
+    val results = findMatchingCalls(query)
+
+    results shouldBe Set("bad2")
+  }
 }

--- a/src/test/scala/io/joern/scanners/c/DangerousFunctionsTests.scala
+++ b/src/test/scala/io/joern/scanners/c/DangerousFunctionsTests.scala
@@ -9,70 +9,51 @@ class DangerousFunctionsTests extends QueryTestSuite {
   override def queryBundle = DangerousFunctions
 
   "find insecure gets() function usage" in {
-    queryBundle.getsUsed()(cpg).map(_.evidence) match {
-      case List(List(expr: nodes.Expression)) =>{
-        expr.method.name shouldBe "insecure_gets"
-      }
-      case _ => fail()
-    }
+    val query = queryBundle.getsUsed()
+    val results = findMatchingCalls(query)
+
+    results shouldBe (Set("insecure_gets"))
   }
 
   "find insecure printf() function usage" in {
-    val results =
-      queryBundle.argvUsedInPrintf()(cpg)
-      .flatMap(_.evidence)
-      .collect { case x: nodes.Call => x }
-      .method
-      .name
-      .toSet
+    val query = queryBundle.argvUsedInPrintf()
+    val results = findMatchingCalls(query)
+
     results shouldBe Set("insecure_sprintf", "insecure_printf")
   }
 
   "find insecure scanf() function usage" in {
-    queryBundle.scanfUsed()(cpg).map(_.evidence) match {
-      case List(List(expr: nodes.Expression)) =>
-        expr.method.name shouldBe "insecure_scanf"
-      case _ => fail()
-    }
+    val query = queryBundle.scanfUsed()
+    val results = findMatchingCalls(query)
+
+    results shouldBe Set("insecure_scanf")
   }
 
   "find insecure strncat() function usage" in {
-    val results =
-      queryBundle.strcatUsed()(cpg)
-      .flatMap(_.evidence)
-      .collect { case x: nodes.Call => x }
-      .method
-      .name
-      .toSet
+    val query = queryBundle.strcatUsed()
+    val results = findMatchingCalls(query)
 
     results shouldBe Set("insecure_strcat", "insecure_strncat")
   }
 
   "find insecure strncpy() function usage" in {
-    val results =
-      queryBundle.strcpyUsed()(cpg)
-      .flatMap(_.evidence)
-      .collect { case x: nodes.Call => x }
-      .method
-      .name
-      .toSet
+    val query = queryBundle.strcpyUsed()
+    val results = findMatchingCalls(query)
 
     results shouldBe Set("insecure_strcpy", "insecure_strncpy")
   }
 
   "find insecure strtok() function usage" in {
-    queryBundle.strtokUsed()(cpg).map(_.evidence) match {
-      case List(List(expr: nodes.Expression)) =>
-        expr.method.name shouldBe "insecure_strtok"
-      case _ => fail()
-    }
+    val query = queryBundle.strtokUsed()
+    val results = findMatchingCalls(query)
+
+    results shouldBe Set("insecure_strtok")
   }
 
   "find insecure getwd() function usage" in {
-    queryBundle.getwdUsed()(cpg).map(_.evidence) match {
-      case List(List(expr: nodes.Expression)) =>
-        expr.method.name shouldBe "insecure_getwd"
-      case _ => fail()
-    }
+    val query = queryBundle.getwdUsed()
+    val results = findMatchingCalls(query)
+
+    results shouldBe Set("insecure_getwd")
   }
 }

--- a/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
+++ b/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
@@ -9,13 +9,9 @@ class FileOpRaceTests extends QueryTestSuite {
   override def queryBundle = FileOpRace
 
   "should flag function `insecure_race` only" in {
-    val queries = queryBundle.fileOperationRace()
-    val results = queries(cpg)
-      .flatMap(_.evidence)
-      .collect { case x: nodes.Call => x }
-      .method
-      .name
-      .toSet
+    val query = queryBundle.fileOperationRace()
+    val results = findMatchingCalls(query)
+
     results shouldBe Set("insecure_race")
   }
 

--- a/src/test/scala/io/joern/scanners/c/NullTerminationTests.scala
+++ b/src/test/scala/io/joern/scanners/c/NullTerminationTests.scala
@@ -9,13 +9,23 @@ class NullTerminationTests extends QueryTestSuite {
   override def queryBundle = NullTermination
 
   "should find the bad code and not report the good" in {
-    val x = queryBundle.strncpyNoNullTerm()
-    x(cpg).flatMap(_.evidence) match {
-      case List(x: nodes.Expression) =>
-        x.method.name shouldBe "bad"
-      case _ =>
-        fail()
-    }
+
+    val query = queryBundle.strncpyNoNullTerm()
+    val results = query(cpg)
+      .flatMap(_.evidence)
+      .collect { case expr: nodes.Expression => expr }
+      .method
+      .name
+      .toSetImmutable
+
+    results shouldBe Set("bad")
+//    val query = queryBundle.strncpyNoNullTerm()
+//    query(cpg).flatMap(_.evidence) match {
+//      case List(x: nodes.Expression) =>
+//        x.method.name shouldBe "bad"
+//      case _ =>
+//        fail()
+//    }
   }
 
 }

--- a/src/test/scala/io/joern/scanners/c/QueryTestSuite.scala
+++ b/src/test/scala/io/joern/scanners/c/QueryTestSuite.scala
@@ -1,8 +1,13 @@
 package io.joern.scanners.c
 
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.console.{DefaultArgumentProvider, Query, QueryBundle, QueryDatabase}
+import io.shiftleft.console.scan._
+import io.shiftleft.semanticcpg.language._
 import io.shiftleft.dataflowengineoss.queryengine.EngineContext
 import io.shiftleft.dataflowengineoss.semanticsloader.{Parser, Semantics}
+import overflowdb.{Node, NodeRef}
 
 import scala.reflect.runtime.universe._
 
@@ -48,6 +53,18 @@ class QueryTestSuite extends Suite {
             .negative
             .mkString("\n"))
   }.mkString("\n")
+
+  /**
+    * Used for tests that match names of vulnerable functions
+    */
+  def findMatchingCalls(query: Query): Set[String] = {
+    query(cpg)
+      .flatMap(_.evidence)
+      .collect { case call: nodes.Call => call }
+      .method
+      .name
+      .toSetImmutable
+  }
 
   override val code = concatedQueryCodeExamples
 }

--- a/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
+++ b/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
@@ -9,11 +9,10 @@ class RetvalChecksTests extends QueryTestSuite {
   override def queryBundle = RetvalChecks
 
   "should find unchecked read and not flag others" in {
-    val results =
-      queryBundle.uncheckedReadRecvMalloc()(cpg).flatMap(_.evidence).collect {
-        case call: nodes.Call => call.method.name
-      }
-    results.toSet shouldBe Set("unchecked_read", "checks_something_else")
+    val query = queryBundle.uncheckedReadRecvMalloc()
+    val results = findMatchingCalls(query)
+
+    results shouldBe Set("unchecked_read", "checks_something_else")
   }
 
 }

--- a/src/test/scala/io/joern/scanners/c/SignedLeftShiftTests.scala
+++ b/src/test/scala/io/joern/scanners/c/SignedLeftShiftTests.scala
@@ -9,15 +9,10 @@ class SignedLeftShiftTests extends QueryTestSuite {
   override def queryBundle = SignedLeftShift
 
   "find signed left shift" in {
-    queryBundle
-      .signedLeftShift()(cpg)
-      .flatMap(_.evidence)
-      .map {
-        case c: nodes.Call =>
-          c.method.name
-        case _ => fail()
-      }
-      .toSet shouldBe Set("bad1", "bad2", "bad3")
+    val query = queryBundle.signedLeftShift()
+    val results = findMatchingCalls(query)
+
+    results shouldBe Set("bad1", "bad2", "bad3")
   }
 
 }

--- a/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
+++ b/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
@@ -31,13 +31,9 @@ class SocketApiTests extends QueryTestSuite {
       |""".stripMargin
 
   "should flag function `return_not_checked` only" in {
-    val queries = queryBundle.uncheckedSend()
-    val results = queries(cpg)
-      .flatMap(_.evidence)
-      .collect { case x: nodes.Call => x }
-      .method
-      .name
-      .toSet
+    val query = queryBundle.uncheckedSend()
+    val results = findMatchingCalls(query)
+
     results shouldBe Set("return_not_checked")
   }
 

--- a/src/test/scala/io/joern/scanners/c/Suite.scala
+++ b/src/test/scala/io/joern/scanners/c/Suite.scala
@@ -1,6 +1,5 @@
 package io.joern.scanners.c
 
-import io.shiftleft.console.Query
 import io.shiftleft.fuzzyc2cpg.testfixtures.DataFlowCodeToCpgSuite
 
 class Suite extends DataFlowCodeToCpgSuite {

--- a/src/test/scala/io/joern/scanners/c/UseAfterFreeTests.scala
+++ b/src/test/scala/io/joern/scanners/c/UseAfterFreeTests.scala
@@ -31,10 +31,9 @@ class UseAfterFreeTests extends QueryTestSuite {
 
 
   "should flag `bad` function only" in {
-    val x = queryBundle.freeFieldNoReassign()
-    x(cpg)
-      .flatMap(_.evidence)
-      .collect { case call: nodes.Call => call.method.name }
-      .toSet shouldBe Set("bad")
+    val query = queryBundle.freeFieldNoReassign()
+    val results = findMatchingCalls(query)
+
+    results shouldBe Set("bad")
   }
 }


### PR DESCRIPTION
# Notes
There is a very common pattern in the `query-database` unit tests which is to find `Call` nodes which match a query, get the method names for the methods in which these calls are made and then compare the list of method names to the expected results. This PR refactors these testcases to use a standard implementation, both to make them easier to read as well as to implement similar tests in future.

# Testing
`sbt clean test createDistribution`