### PR TITLE
Fix minor issues due to fuzzy and new c parser discrepancies

### DIFF
--- a/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
+++ b/src/main/scala/io/joern/scanners/c/DangerousFunctions.scala
@@ -318,7 +318,7 @@ object DangerousFunctions extends QueryBundle {
           |void secure_getcwd(char *buf, size_t len) {
           |    getcwd(buf, len);
           |}
-          |""")
+          |""".stripMargin)
       )
     )
 }

--- a/src/main/scala/io/joern/scanners/c/Metrics.scala
+++ b/src/main/scala/io/joern/scanners/c/Metrics.scala
@@ -167,7 +167,7 @@ object Metrics extends QueryBundle {
         cpg.method.internal
           .filter(
             _.ast.isControlStructure
-              .parserTypeName("(For|Do|While).*")
+              .controlStructureType("(FOR|DO|WHILE)")
               .size > n)
       }),
       tags = List(QueryTags.metrics),
@@ -230,7 +230,7 @@ object Metrics extends QueryBundle {
           |  }
           |}
           |
-          |""")
+          |""".stripMargin)
       )
     )
 }


### PR DESCRIPTION
# Notes 
* The missing `stripMargin` led to the code examples not being parsed properly. This meant that the functions in question weren't being tested at all, but due to how the `code` used for the tests is constructed, it also interfered with other testcases.
* The new parser prepends `CAST` or `CPPAST` to the `parserTypeName`, so that regex doesn't work for the new front-end. An alternative solution is to match the `parserTypeName` to `(CAST|CPPAST)?(For|Do|While)`, but using the `controlStructureType` field seems more robust.
# Testing
`sbt clean test createDistribution`