### PR TITLE
Upgrade Github PR action to JDK11 and add javac and scalac version flags

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 1.11
+        java-version: 11
     - name: Run tests
       run: |
         sbt test scalafmtCheck stage

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,10 +5,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: 1.11
     - name: Run tests
       run: |
         sbt test scalafmtCheck stage

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ two purposes:
 
 * It provides the batteries required to turn Joern into a ready-to-run code scanning tool.
 * Its queries serve as examples useful for those looking to write their own queries.
+* [built on JDK11](https://github.com/ShiftLeftSecurity/overflowdb/blob/master/.github/workflows/release.yml) but runs on JRE > 1.8
 
 The query database is distributed as a standalone library that
 includes Joern as a dependency. This means that it is not necessary to

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,11 @@ ThisBuild/Compile/scalacOptions ++= Seq(
   "-feature",
   "-deprecation",
   "-language:implicitConversions",
+  "-target:jvm-1.8",
 )
+
+ThisBuild/javacOptions ++= Seq("-source", "1.8")
+ThisBuild/Test/compile/javacOptions ++= Seq("-g", "-target", "1.8")
 
 ThisBuild/licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 


### PR DESCRIPTION
# Notes 
This PR upgrades the JDK version used for the PR tests to JDK11 to fix https://github.com/joernio/query-database/actions/runs/1135767057.

# Testing
`sbt clean test` + Github tests once the PR has been submitted.